### PR TITLE
Enable popup-style settings dialog

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -154,6 +154,20 @@ class _MainScreenState extends State<MainScreen> {
     });
   }
 
+  void _showSettingsDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return Dialog(
+          child: SizedBox(
+            width: double.infinity,
+            child: const SettingsTabContent(),
+          ),
+        );
+      },
+    );
+  }
+
   final Color _selectedItemBackgroundColor = const Color(0x33FFFF00);
 
   Widget _buildActiveIcon(IconData icon, BuildContext context, int itemIndex) {
@@ -215,9 +229,7 @@ class _MainScreenState extends State<MainScreen> {
             IconButton(
               icon: const Icon(Icons.settings_outlined),
               tooltip: '設定',
-              onPressed: () {
-                _navigateTo(AppScreen.settings);
-              },
+              onPressed: _showSettingsDialog,
             ),
         ],
       ),

--- a/lib/tabs_content/settings_tab_content.dart
+++ b/lib/tabs_content/settings_tab_content.dart
@@ -49,6 +49,7 @@ class _SettingsTabContentState extends State<SettingsTabContent> {
 
     return ListView(
       padding: const EdgeInsets.all(16.0),
+      shrinkWrap: true,
       children: <Widget>[
         // --- ダークモード設定 ---
         ListTile(


### PR DESCRIPTION
## Summary
- show a popup dialog for the settings UI
- allow SettingsTabContent to be embedded in a dialog

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e1f97318832a9d30fb68d3e390c8