### PR TITLE
Implement quiz results navigation

### DIFF
--- a/lib/quiz_in_progress_screen.dart
+++ b/lib/quiz_in_progress_screen.dart
@@ -4,6 +4,7 @@ import 'package:hive/hive.dart';
 
 import 'flashcard_model.dart';
 import 'quiz_setup_screen.dart';
+import 'quiz_results_screen.dart';
 
 const String favoritesBoxName = 'favorites_box_v2';
 
@@ -109,7 +110,15 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
 
   void _nextQuestion() {
     if (_currentIndex + 1 >= widget.totalSessionQuestions) {
-      print('Navigate to Results Screen');
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (_) => QuizResultsScreen(
+            totalQuestions: widget.totalSessionQuestions,
+            score: _score,
+            answerResults: _answerResults,
+          ),
+        ),
+      );
       return;
     }
     setState(() {
@@ -138,7 +147,15 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
       },
     );
     if (result == true) {
-      print('Navigate to Results Screen');
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (_) => QuizResultsScreen(
+            totalQuestions: widget.totalSessionQuestions,
+            score: _score,
+            answerResults: _answerResults,
+          ),
+        ),
+      );
     }
   }
 
@@ -249,7 +266,11 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
         const SizedBox(height: 24),
         ElevatedButton(
           onPressed: _nextQuestion,
-          child: const Text('次の問題へ'),
+          child: Text(
+            _currentIndex + 1 >= widget.totalSessionQuestions
+                ? '結果画面へ'
+                : '次の問題へ',
+          ),
         ),
       ],
     );

--- a/lib/quiz_results_screen.dart
+++ b/lib/quiz_results_screen.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class QuizResultsScreen extends StatelessWidget {
+  final int totalQuestions;
+  final int score;
+  final List<bool> answerResults;
+
+  const QuizResultsScreen({
+    Key? key,
+    required this.totalQuestions,
+    required this.score,
+    required this.answerResults,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('結果'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'スコア: $score / $totalQuestions',
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).popUntil((route) => route.isFirst);
+              },
+              child: const Text('ホームへ戻る'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show `結果画面へ` on the last quiz question
- navigate to new `QuizResultsScreen` when quiz finishes or the user quits
- implement basic results screen showing score

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843e292fda4832a886115f6d9cf3c1e