### PR TITLE
Add close button to settings screen

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -89,7 +89,12 @@ class _MainScreenState extends State<MainScreen> {
           navigateTo: _navigateTo,
         );
       case AppScreen.settings:
-        return const SettingsTabContent(key: ValueKey("SettingsTabContent"));
+        return SettingsTabContent(
+          key: const ValueKey("SettingsTabContent"),
+          onClose: () {
+            _navigateTo(_mapBottomNavIndexToAppScreen(_bottomNavIndex));
+          },
+        );
     }
   }
 

--- a/lib/tabs_content/settings_tab_content.dart
+++ b/lib/tabs_content/settings_tab_content.dart
@@ -5,7 +5,9 @@ import 'package:provider/provider.dart';
 import '../theme_provider.dart'; // lib/theme_provider.dart をインポート
 
 class SettingsTabContent extends StatefulWidget {
-  const SettingsTabContent({Key? key}) : super(key: key);
+  final VoidCallback? onClose;
+
+  const SettingsTabContent({Key? key, this.onClose}) : super(key: key);
 
   @override
   _SettingsTabContentState createState() => _SettingsTabContentState();
@@ -93,6 +95,17 @@ class _SettingsTabContentState extends State<SettingsTabContent> {
         ),
         Divider(),
         // ... (残りの設定項目)
+
+        const SizedBox(height: 24),
+        Center(
+          child: ElevatedButton.icon(
+            onPressed: widget.onClose ?? () {
+              Navigator.of(context).maybePop();
+            },
+            icon: const Icon(Icons.close),
+            label: const Text('閉じる'),
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- allow `SettingsTabContent` to receive a close callback
- show an elevated close button at the bottom of settings
- wire the close button to navigate back to the prior tab

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e5a6b2e0832aa0d1fc4d876b255b