### PR TITLE
Add quiz result listing

### DIFF
--- a/lib/quiz_in_progress_screen.dart
+++ b/lib/quiz_in_progress_screen.dart
@@ -4,6 +4,7 @@ import 'package:hive/hive.dart';
 
 import 'flashcard_model.dart';
 import 'quiz_setup_screen.dart';
+import 'quiz_result_screen.dart';
 
 const String favoritesBoxName = 'favorites_box_v2';
 
@@ -109,13 +110,31 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
 
   void _nextQuestion() {
     if (_currentIndex + 1 >= widget.totalSessionQuestions) {
-      print('Navigate to Results Screen');
+      _goToResults();
       return;
     }
     setState(() {
       _currentIndex++;
     });
     _loadQuestion();
+  }
+
+  void _goToResults() {
+    if (_answerResults.length < widget.totalSessionQuestions) {
+      _answerResults.addAll(
+        List.filled(
+            widget.totalSessionQuestions - _answerResults.length, false),
+      );
+    }
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => QuizResultScreen(
+          words: widget.quizSessionWords,
+          answerResults: _answerResults,
+          score: _score,
+        ),
+      ),
+    );
   }
 
   Future<void> _confirmQuit() async {
@@ -138,7 +157,7 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
       },
     );
     if (result == true) {
-      print('Navigate to Results Screen');
+      _goToResults();
     }
   }
 

--- a/lib/quiz_result_screen.dart
+++ b/lib/quiz_result_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'flashcard_model.dart';
+
+class QuizResultScreen extends StatefulWidget {
+  final List<Flashcard> words;
+  final List<bool> answerResults;
+  final int score;
+
+  const QuizResultScreen({
+    Key? key,
+    required this.words,
+    required this.answerResults,
+    required this.score,
+  }) : super(key: key);
+
+  @override
+  State<QuizResultScreen> createState() => _QuizResultScreenState();
+}
+
+class _QuizResultScreenState extends State<QuizResultScreen> {
+  bool _showDescriptions = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('結果')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'スコア: ${widget.score} / ${widget.words.length}',
+            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          SwitchListTile(
+            title: const Text('単語概要を表示'),
+            value: _showDescriptions,
+            onChanged: (val) => setState(() => _showDescriptions = val),
+          ),
+          const SizedBox(height: 16),
+          ...List.generate(widget.words.length, (index) {
+            final card = widget.words[index];
+            final bool correct = index < widget.answerResults.length && widget.answerResults[index];
+            return Card(
+              margin: const EdgeInsets.symmetric(vertical: 4),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text('Q${index + 1}: ', style: const TextStyle(fontWeight: FontWeight.bold)),
+                        Expanded(child: Text(card.term, style: const TextStyle(fontSize: 16))),
+                        Icon(
+                          correct ? Icons.circle : Icons.close,
+                          color: correct ? Colors.green : Colors.red,
+                          size: 20,
+                        ),
+                      ],
+                    ),
+                    if (_showDescriptions) ...[
+                      const SizedBox(height: 8),
+                      Text(card.description),
+                    ],
+                  ],
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a results screen to list words from the quiz
- navigate to the new screen when the quiz ends or is quit
- keep a toggle to show or hide word descriptions

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843e668d658832abec1d639f4a75a98