### PR TITLE
Display question text and choices on quiz results

### DIFF
--- a/lib/quiz_in_progress_screen.dart
+++ b/lib/quiz_in_progress_screen.dart
@@ -31,6 +31,7 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
   int _currentIndex = 0;
   int _score = 0;
   List<bool> _answerResults = [];
+  final List<List<String>> _choicesHistory = [];
 
   late Flashcard _currentFlashcard;
   List<Flashcard> _choices = [];
@@ -88,6 +89,7 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
     List<Flashcard> incorrect = pool.take(3).toList();
     _choices = [_currentFlashcard, ...incorrect];
     _choices.shuffle(Random());
+    _choicesHistory.add(_choices.map((c) => c.term).toList());
   }
 
   void _loadQuestion() {
@@ -146,6 +148,7 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
           words: widget.quizSessionWords,
           answerResults: _answerResults,
           score: _score,
+          choices: _choicesHistory,
         ),
       ),
     );

--- a/lib/quiz_result_screen.dart
+++ b/lib/quiz_result_screen.dart
@@ -5,12 +5,14 @@ class QuizResultScreen extends StatefulWidget {
   final List<Flashcard> words;
   final List<bool> answerResults;
   final int score;
+  final List<List<String>> choices;
 
   const QuizResultScreen({
     Key? key,
     required this.words,
     required this.answerResults,
     required this.score,
+    required this.choices,
   }) : super(key: key);
 
   @override
@@ -19,6 +21,7 @@ class QuizResultScreen extends StatefulWidget {
 
 class _QuizResultScreenState extends State<QuizResultScreen> {
   bool _showDescriptions = true;
+  bool _showChoices = false;
 
   @override
   Widget build(BuildContext context) {
@@ -36,10 +39,19 @@ class _QuizResultScreenState extends State<QuizResultScreen> {
             value: _showDescriptions,
             onChanged: (val) => setState(() => _showDescriptions = val),
           ),
+          SwitchListTile(
+            title: const Text('選択肢を表示'),
+            value: _showChoices,
+            onChanged: (val) => setState(() => _showChoices = val),
+          ),
           const SizedBox(height: 16),
           ...List.generate(widget.words.length, (index) {
             final card = widget.words[index];
-            final bool correct = index < widget.answerResults.length && widget.answerResults[index];
+            final bool correct = index < widget.answerResults.length &&
+                widget.answerResults[index];
+            final choices = index < widget.choices.length
+                ? widget.choices[index]
+                : <String>[];
             return Card(
               margin: const EdgeInsets.symmetric(vertical: 4),
               child: Padding(
@@ -49,8 +61,9 @@ class _QuizResultScreenState extends State<QuizResultScreen> {
                   children: [
                     Row(
                       children: [
-                        Text('Q${index + 1}: ', style: const TextStyle(fontWeight: FontWeight.bold)),
-                        Expanded(child: Text(card.term, style: const TextStyle(fontSize: 16))),
+                        Text('Q${index + 1}',
+                            style: const TextStyle(fontWeight: FontWeight.bold)),
+                        const SizedBox(width: 8),
                         Icon(
                           correct ? Icons.circle : Icons.close,
                           color: correct ? Colors.green : Colors.red,
@@ -61,6 +74,23 @@ class _QuizResultScreenState extends State<QuizResultScreen> {
                     if (_showDescriptions) ...[
                       const SizedBox(height: 8),
                       Text(card.description),
+                    ],
+                    const SizedBox(height: 8),
+                    Text('正解: ${card.term}',
+                        style: const TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.bold)),
+                    if (_showChoices && choices.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      ...choices.map((c) => Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 2),
+                            child: Text(
+                              c,
+                              style: TextStyle(
+                                color:
+                                    c == card.term ? Colors.green : Colors.black,
+                              ),
+                            ),
+                          )),
                     ],
                   ],
                 ),


### PR DESCRIPTION
## Summary
- store every question's choices during the quiz session
- forward the choices to the results screen
- add toggle to display choices
- reorganise results screen cards to emphasize the question and correct word

## Testing
- `flutter format lib/quiz_in_progress_screen.dart lib/quiz_result_screen.dart` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684417b6a494832a850f7d77ca4650ce