### PR TITLE
Open settings in popup

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -89,7 +89,12 @@ class _MainScreenState extends State<MainScreen> {
           navigateTo: _navigateTo,
         );
       case AppScreen.settings:
-        return const SettingsTabContent(key: ValueKey("SettingsTabContent"));
+        return SettingsTabContent(
+          key: const ValueKey("SettingsTabContent"),
+          onClose: () {
+            _navigateTo(_mapBottomNavIndexToAppScreen(_bottomNavIndex));
+          },
+        );
     }
   }
 
@@ -216,7 +221,21 @@ class _MainScreenState extends State<MainScreen> {
               icon: const Icon(Icons.settings_outlined),
               tooltip: '設定',
               onPressed: () {
-                _navigateTo(AppScreen.settings);
+                showDialog(
+                  context: context,
+                  builder: (dialogContext) {
+                    return Dialog(
+                      child: SizedBox(
+                        width: double.maxFinite,
+                        child: SettingsTabContent(
+                          onClose: () {
+                            Navigator.of(dialogContext).pop();
+                          },
+                        ),
+                      ),
+                    );
+                  },
+                );
               },
             ),
         ],

--- a/lib/tabs_content/settings_tab_content.dart
+++ b/lib/tabs_content/settings_tab_content.dart
@@ -5,7 +5,9 @@ import 'package:provider/provider.dart';
 import '../theme_provider.dart'; // lib/theme_provider.dart をインポート
 
 class SettingsTabContent extends StatefulWidget {
-  const SettingsTabContent({Key? key}) : super(key: key);
+  final VoidCallback? onClose;
+
+  const SettingsTabContent({Key? key, this.onClose}) : super(key: key);
 
   @override
   _SettingsTabContentState createState() => _SettingsTabContentState();
@@ -93,6 +95,17 @@ class _SettingsTabContentState extends State<SettingsTabContent> {
         ),
         Divider(),
         // ... (残りの設定項目)
+
+        const SizedBox(height: 24),
+        Center(
+          child: ElevatedButton.icon(
+            onPressed: widget.onClose ?? () {
+              Navigator.of(context).maybePop();
+            },
+            icon: const Icon(Icons.close),
+            label: const Text('閉じる'),
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- open settings as a dialog rather than navigating to a dedicated screen
- keep close button inside `SettingsTabContent`

## Testing
- `dart format lib/main_screen.dart lib/tabs_content/settings_tab_content.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e5a6b2e0832aa0d1fc4d876b255b