### PR TITLE
Fix app bar title update

### DIFF
--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -508,6 +508,8 @@ class _WordDetailContentState extends State<WordDetailContent> {
               _loadFavoriteStatus();
               _addHistoryEntry();
               _pushHistory();
+              // AppBarの表示を更新
+              widget.controller?.update();
             },
             itemBuilder: (context, index) {
               return _buildFlashcardDetail(context, _displayFlashcards[index]);


### PR DESCRIPTION
## Summary
- ensure the app bar title shows the currently displayed word

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d5a1b55c832aac8c6928860f5b41