### PR TITLE
Implement per-tag statistics

### DIFF
--- a/lib/tag_stats.dart
+++ b/lib/tag_stats.dart
@@ -1,0 +1,18 @@
+class TagStats {
+  int totalAttempts;
+  int totalWrong;
+
+  TagStats({this.totalAttempts = 0, this.totalWrong = 0});
+
+  factory TagStats.fromMap(Map<dynamic, dynamic> map) {
+    return TagStats(
+      totalAttempts: (map['totalAttempts'] as int?) ?? 0,
+      totalWrong: (map['totalWrong'] as int?) ?? 0,
+    );
+  }
+
+  Map<String, int> toMap() => {
+        'totalAttempts': totalAttempts,
+        'totalWrong': totalWrong,
+      };
+}


### PR DESCRIPTION
## Summary
- add `TagStats` model
- track tag statistics when recording quiz results
- compute tag weakness using saved tag stats

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579a2960c0832a88793e67f370e397