### PR TITLE
Add review mode control

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -14,6 +14,7 @@ import 'tabs_content/settings_tab_content.dart'; // 設定画面コンテンツ
 import 'learning_history_detail_screen.dart';
 import 'about_screen.dart';
 import 'today_summary_screen.dart';
+import 'review_service.dart';
 import 'word_detail_content.dart'; // 詳細表示用コンテンツウィジェット
 import 'word_detail_controller.dart';
 
@@ -30,6 +31,7 @@ class _MainScreenState extends State<MainScreen> {
   final WordDetailController _detailController = WordDetailController();
   final GlobalKey<WordListTabContentState> _wordListKey =
       GlobalKey<WordListTabContentState>();
+  ReviewMode _reviewMode = ReviewMode.random;
 
   String _getAppBarTitle() {
     switch (_currentScreen) {
@@ -78,6 +80,7 @@ class _MainScreenState extends State<MainScreen> {
       case AppScreen.wordList:
         return WordListTabContent(
           key: _wordListKey,
+          mode: _reviewMode,
           onWordTap: (flashcards, index) {
             _navigateTo(
               AppScreen.wordDetail,
@@ -119,6 +122,7 @@ class _MainScreenState extends State<MainScreen> {
           // ★ navigateTo を渡す
           key: const ValueKey("QuizTabContent"),
           navigateTo: _navigateTo,
+          mode: _reviewMode,
         );
       case AppScreen.todaySummary:
         return TodaySummaryScreen(
@@ -206,6 +210,25 @@ class _MainScreenState extends State<MainScreen> {
         .colorScheme
         .secondary
         .withOpacity(0.2);
+  }
+
+  String _labelForMode(ReviewMode mode) {
+    switch (mode) {
+      case ReviewMode.newWords:
+        return '新出語';
+      case ReviewMode.random:
+        return 'ランダム';
+      case ReviewMode.wrongDescending:
+        return '間違え順';
+      case ReviewMode.tagFocus:
+        return 'タグ集中';
+      case ReviewMode.spacedRepetition:
+        return '復習間隔順';
+      case ReviewMode.mixed:
+        return '総合優先度';
+      case ReviewMode.tagOnly:
+        return 'タグのみ';
+    }
   }
 
   Widget _buildActiveIcon(IconData icon, BuildContext context, int itemIndex) {
@@ -307,6 +330,26 @@ class _MainScreenState extends State<MainScreen> {
                   )
                 : null),
         actions: [
+          if (_currentScreen == AppScreen.wordList || _currentScreen == AppScreen.quiz)
+            DropdownButtonHideUnderline(
+              child: DropdownButton<ReviewMode>(
+                value: _reviewMode,
+                icon: const Icon(Icons.arrow_drop_down),
+                onChanged: (mode) {
+                  if (mode == null) return;
+                  setState(() {
+                    _reviewMode = mode;
+                  });
+                  _wordListKey.currentState?.updateMode(mode);
+                },
+                items: ReviewMode.values
+                    .map((m) => DropdownMenuItem(
+                          value: m,
+                          child: Text(_labelForMode(m)),
+                        ))
+                    .toList(),
+              ),
+            ),
           if (_currentScreen == AppScreen.wordList)
             IconButton(
               icon: const Icon(Icons.filter_alt_outlined),

--- a/lib/quiz_setup_screen.dart
+++ b/lib/quiz_setup_screen.dart
@@ -4,31 +4,22 @@ import 'flashcard_model.dart';
 import 'review_service.dart';
 import 'quiz_in_progress_screen.dart';
 
-// Review modes for selecting question order
-enum ReviewMode {
-  newWords,
-  random,
-  wrongDescending,
-  tagFocus,
-  spacedRepetition,
-  mixed,
-  tagOnly,
-}
-
 // Quiz type options
 enum QuizType { multipleChoice, flashcard }
 
 /// Quiz setup screen widget.
 /// Users configure quiz options before starting a session.
 class QuizSetupScreen extends StatefulWidget {
-  const QuizSetupScreen({Key? key}) : super(key: key);
+  final ReviewMode mode;
+
+  const QuizSetupScreen({Key? key, required this.mode}) : super(key: key);
 
   @override
   State<QuizSetupScreen> createState() => _QuizSetupScreenState();
 }
 
 class _QuizSetupScreenState extends State<QuizSetupScreen> {
-  ReviewMode _mode = ReviewMode.random;
+  late ReviewMode _mode;
   QuizType _quizType = QuizType.multipleChoice;
   int _questionCount = 10;
   bool _loadingCount = false;
@@ -38,6 +29,22 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     'yellow': true,
     'blue': true,
   };
+
+  @override
+  void initState() {
+    super.initState();
+    _mode = widget.mode;
+  }
+
+  @override
+  void didUpdateWidget(covariant QuizSetupScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.mode != oldWidget.mode) {
+      setState(() {
+        _mode = widget.mode;
+      });
+    }
+  }
 
   /// Fetch available word count for a review mode.
   Future<int> fetchAvailableWordCount(ReviewMode mode) async {

--- a/lib/tabs_content/quiz_tab_content.dart
+++ b/lib/tabs_content/quiz_tab_content.dart
@@ -2,16 +2,19 @@
 import 'package:flutter/material.dart';
 import '../app_view.dart'; // AppScreenとScreenArgumentsのため (もしnavigateToで使うなら)
 import '../quiz_setup_screen.dart';
+import '../review_service.dart';
 
 class QuizTabContent extends StatelessWidget {
   // navigateToコールバックを受け取るためのfinal変数を追加
   final Function(AppScreen screen, {ScreenArguments? args})? navigateTo;
+  final ReviewMode mode;
 
   // コンストラクタでnavigateToを受け取るように修正 (任意パラメータとして)
-  const QuizTabContent({Key? key, this.navigateTo}) : super(key: key);
+  const QuizTabContent({Key? key, this.navigateTo, required this.mode})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return const QuizSetupScreen();
+    return QuizSetupScreen(mode: mode);
   }
 }


### PR DESCRIPTION
## Summary
- control ReviewMode globally from MainScreen app bar
- reload WordListTabContent using ReviewService when mode changes
- pass review mode into quiz setup and quiz tab

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579b3ece5c832aa54fa9e9bda1c16c