### PR TITLE
Implement auto filter mode

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -228,6 +228,8 @@ class _MainScreenState extends State<MainScreen> {
         return '総合優先度';
       case ReviewMode.tagOnly:
         return 'タグのみ';
+      case ReviewMode.autoFilter:
+        return '🌀 自動フィルターモード';
     }
   }
 

--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -74,7 +74,12 @@ class WordListTabContentState extends State<WordListTabContent> {
     });
     try {
       final service = ReviewService();
-      final loadedCards = await service.fetchForMode(_mode);
+      List<Flashcard> loadedCards;
+      if (_mode == ReviewMode.autoFilter) {
+        loadedCards = await service.topByPriority(200);
+      } else {
+        loadedCards = await service.fetchForMode(_mode);
+      }
       final tagSet = <String>{};
       for (var card in loadedCards) {
         if (card.tags != null) tagSet.addAll(card.tags!);


### PR DESCRIPTION
## Summary
- add `autoFilter` entry to `ReviewMode`
- expose `topByPriority` in `ReviewService`
- show "🌀 自動フィルターモード" label in UI
- load top 200 words by priority on the word list when this mode is active

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579d612ad8832aafcc39b32847c70b