### PR TITLE
Organize imports and repository reference

### DIFF
--- a/lib/quiz_in_progress_screen.dart
+++ b/lib/quiz_in_progress_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 
 import 'flashcard_model.dart';
+import 'flashcard_repository.dart';
 import 'quiz_setup_screen.dart';
 import 'quiz_result_screen.dart';
 

--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -5,16 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 
 import '../history_entry_model.dart';
-
-const String historyBoxName = 'history_box_v2';
-const String quizStatsBoxName = 'quiz_stats_box_v1';
-
-enum SortMode { id, importance, lastReviewed }
-enum FilterMode { unviewed, wrongOnly }
-
 import '../flashcard_model.dart'; // lib/flashcard_model.dart
 import '../review_service.dart';
 // import '../word_detail_screen.dart'; // MainScreen が管理するので直接は不要
+
+enum SortMode { id, importance, lastReviewed }
+enum FilterMode { unviewed, wrongOnly }
 
 class WordListTabContent extends StatefulWidget {
   final Function(List<Flashcard>, int) onWordTap; // 単語タップ時のコールバック
@@ -405,6 +401,9 @@ class WordListTabContentState extends State<WordListTabContent> {
     );
   }
 }
+
+const String historyBoxName = 'history_box_v2';
+const String quizStatsBoxName = 'quiz_stats_box_v1';
 
 class FilterSheet extends StatefulWidget {
   final String searchQuery;


### PR DESCRIPTION
## Summary
- gather imports at top of `word_list_tab_content.dart`
- move box constants below `WordListTabContentState`
- add FlashcardRepository import to `quiz_in_progress_screen.dart`

## Testing
- `flutter build web --base-href /tango/ --pwa-strategy=none` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a62226b0832ab549a1d964a71a01