### PR TITLE
Implement WordListQuery and refactor word list tab

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -1,6 +1,10 @@
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
+import 'package:hive/hive.dart';
+
+import 'history_entry_model.dart';
+import 'word_list_query.dart';
 
 import 'flashcard_model.dart';
 
@@ -64,6 +68,8 @@ class FlashcardRepository {
 
   static FlashcardDataSource _dataSource = LocalFlashcardDataSource();
   static List<Flashcard>? _cache;
+  static const String historyBoxName = 'history_box_v2';
+  static const String quizStatsBoxName = 'quiz_stats_box_v1';
 
   /// Replace the current data source and clear the cache.
   static void setDataSource(FlashcardDataSource source) {
@@ -78,5 +84,70 @@ class FlashcardRepository {
     }
     _cache = await _dataSource.loadAll();
     return _cache!;
+  }
+
+  /// Fetch flashcards matching [query].
+  static Future<List<Flashcard>> fetch(WordListQuery query) async {
+    final all = await loadAll();
+    final historyBox = Hive.box<HistoryEntry>(historyBoxName);
+    final quizStatsBox = Hive.box<Map>(quizStatsBoxName);
+
+    final viewedIds = historyBox.values.map((e) => e.wordId).toSet();
+
+    final Map<String, int> wrongCounts = {};
+    for (final m in quizStatsBox.values) {
+      final ids = (m['wordIds'] as List?)?.cast<String>() ?? [];
+      final results = (m['results'] as List?)?.cast<bool>() ?? [];
+      for (int i = 0; i < ids.length && i < results.length; i++) {
+        if (results[i] == false) {
+          wrongCounts[ids[i]] = (wrongCounts[ids[i]] ?? 0) + 1;
+        }
+      }
+    }
+
+    final Map<String, DateTime> lastReviewed = {};
+    for (final e in historyBox.values) {
+      final prev = lastReviewed[e.wordId];
+      if (prev == null || e.timestamp.isAfter(prev)) {
+        lastReviewed[e.wordId] = e.timestamp;
+      }
+    }
+
+    final String q = query.searchText.trim().toLowerCase();
+
+    List<Flashcard> result = all.where((card) {
+      final matchesQuery = q.isEmpty ||
+          card.term.toLowerCase().contains(q) ||
+          card.reading.toLowerCase().contains(q);
+      bool passesFilter = true;
+      if (query.filters.contains(WordFilter.unviewed)) {
+        passesFilter = passesFilter && !viewedIds.contains(card.id);
+      }
+      if (query.filters.contains(WordFilter.wrongOnly)) {
+        passesFilter = passesFilter && (wrongCounts[card.id] ?? 0) > 0;
+      }
+      return matchesQuery && passesFilter;
+    }).toList();
+
+    switch (query.sort) {
+      case SortType.id:
+        result.sort((a, b) => a.id.compareTo(b.id));
+        break;
+      case SortType.importance:
+        result.sort((a, b) => b.importance.compareTo(a.importance));
+        break;
+      case SortType.lastReviewed:
+        result.sort((a, b) {
+          final at = lastReviewed[a.id];
+          final bt = lastReviewed[b.id];
+          if (at == null && bt == null) return 0;
+          if (at == null) return 1;
+          if (bt == null) return -1;
+          return bt.compareTo(at);
+        });
+        break;
+    }
+
+    return result;
   }
 }

--- a/lib/word_list_query.dart
+++ b/lib/word_list_query.dart
@@ -1,0 +1,41 @@
+/// Query parameters for fetching flashcards.
+///
+/// Includes sorting, filtering and search text.
+
+/// Sorting options for word lists.
+enum SortType { id, importance, lastReviewed }
+
+/// Additional filters when fetching words.
+enum WordFilter { unviewed, wrongOnly }
+
+/// Query used by [FlashcardRepository.fetch] to obtain filtered words.
+class WordListQuery {
+  /// Text used to search `term` or `reading` fields.
+  final String searchText;
+
+  /// Type of sorting to apply when returning results.
+  final SortType sort;
+
+  /// Filters to apply while fetching words.
+  final Set<WordFilter> filters;
+
+  /// Create a new query.
+  const WordListQuery({
+    this.searchText = '',
+    this.sort = SortType.importance,
+    this.filters = const {},
+  });
+
+  /// Return a copy with updated fields.
+  WordListQuery copyWith({
+    String? searchText,
+    SortType? sort,
+    Set<WordFilter>? filters,
+  }) {
+    return WordListQuery(
+      searchText: searchText ?? this.searchText,
+      sort: sort ?? this.sort,
+      filters: filters ?? this.filters,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   fl_chart: ^0.64.0
   http: ^0.13.6
   google_mobile_ads: ^3.0.0
+  flutter_riverpod: ^2.5.0
+  badges: ^3.1.2
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `flutter_riverpod` and `badges` dependencies
- add `WordListQuery` model to manage search and filter state
- implement `FlashcardRepository.fetch` using `WordListQuery`
- refactor word list tab to use Riverpod and new query logic with badges

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fc9ae740832a8910505eda823910