### PR TITLE
Expose WordListTabContentState

### DIFF
--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -19,10 +19,10 @@ class WordListTabContent extends ConsumerStatefulWidget {
   const WordListTabContent({Key? key, required this.onWordTap}) : super(key: key);
 
   @override
-  ConsumerState<WordListTabContent> createState() => _WordListTabContentState();
+  ConsumerState<WordListTabContent> createState() => WordListTabContentState();
 }
 
-class _WordListTabContentState extends ConsumerState<WordListTabContent> {
+class WordListTabContentState extends ConsumerState<WordListTabContent> {
   /// Show bottom sheet to edit the current [WordListQuery].
   void _openQuerySheet(BuildContext context) {
     final current = ref.read(wordListQueryProvider);


### PR DESCRIPTION
## Summary
- make WordListTabContentState a public class
- update createState to use the public state

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580043fd8c832ab476ba79baaf7a7b