### PR TITLE
Remove mode param from WordListTabContent

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -80,7 +80,6 @@ class _MainScreenState extends State<MainScreen> {
       case AppScreen.wordList:
         return WordListTabContent(
           key: _wordListKey,
-          mode: _reviewMode,
           onWordTap: (flashcards, index) {
             _navigateTo(
               AppScreen.wordDetail,


### PR DESCRIPTION
## Summary
- remove outdated `mode` argument from `WordListTabContent` creation in `MainScreen`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858012918bc832aba21880c34a810ef