### PR TITLE
Wrap runApp with ProviderScope

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'main_screen.dart';
 import 'history_entry_model.dart';
 import 'theme_provider.dart';
@@ -60,9 +61,11 @@ Future<void> main() async {
   await themeProvider.loadAppPreferences();
 
   runApp(
-    ChangeNotifierProvider(
-      create: (_) => themeProvider,
-      child: const MyApp(),
+    ProviderScope(
+      child: ChangeNotifierProvider(
+        create: (_) => themeProvider,
+        child: const MyApp(),
+      ),
     ),
   );
 }


### PR DESCRIPTION
## Summary
- wrap `runApp` in `ProviderScope`
- import `flutter_riverpod`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858097400b0832a9d236b3eaaacbfa6