### PR TITLE
Fix provider imports

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter/foundation.dart';
-import 'package:provider/provider.dart';
+import 'package:provider/provider.dart' as provider_pkg;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'main_screen.dart';
 import 'history_entry_model.dart';
@@ -62,7 +62,7 @@ Future<void> main() async {
 
   runApp(
     ProviderScope(
-      child: ChangeNotifierProvider(
+      child: provider_pkg.ChangeNotifierProvider(
         create: (_) => themeProvider,
         child: const MyApp(),
       ),
@@ -133,13 +133,13 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final provider = Provider.of<ThemeProvider>(context);
-    final scale = provider.textScaleFactor;
+    final themeProvider = provider_pkg.Provider.of<ThemeProvider>(context);
+    final scale = themeProvider.textScaleFactor;
     return MaterialApp(
       title: 'IT資格学習 単語帳',
       theme: _buildTheme(Brightness.light),
       darkTheme: _buildTheme(Brightness.dark),
-      themeMode: provider.themeMode,
+      themeMode: themeProvider.themeMode,
       builder: (context, child) {
         return MediaQuery(
           data: MediaQuery.of(context).copyWith(

--- a/lib/tabs_content/settings_tab_content.dart
+++ b/lib/tabs_content/settings_tab_content.dart
@@ -1,7 +1,7 @@
 // lib/tabs_content/settings_tab_content.dart
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:provider/provider.dart' as provider_pkg;
 import '../theme_provider.dart'; // lib/theme_provider.dart をインポート
 
 class SettingsTabContent extends StatefulWidget {
@@ -42,7 +42,7 @@ class _SettingsTabContentState extends State<SettingsTabContent> {
 
   @override
   Widget build(BuildContext context) {
-    final themeProvider = Provider.of<ThemeProvider>(context);
+    final themeProvider = provider_pkg.Provider.of<ThemeProvider>(context);
     bool currentIsDarkMode = themeProvider.isDarkMode;
     // 現在の文字サイズを ThemeProvider から取得
     AppFontSize currentAppFontSize = themeProvider.appFontSize;
@@ -151,7 +151,7 @@ class _SettingsTabContentState extends State<SettingsTabContent> {
                   child: Text('適用'),
                   onPressed: () {
                     // ★★★ ThemeProvider の setAppFontSize を呼び出す ★★★
-                    Provider.of<ThemeProvider>(context, listen: false)
+                    provider_pkg.Provider.of<ThemeProvider>(context, listen: false)
                         .setAppFontSize(selectedFontSizeEnum);
                     Navigator.of(dialogContext).pop();
                   },


### PR DESCRIPTION
## Summary
- alias the provider package imports to reduce ambiguity
- rename local variable to avoid conflict

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580da718c4832aa10dee1f3473b9f2