### PR TITLE
Implement WordListQuery apply method

### DIFF
--- a/lib/word_list_query.dart
+++ b/lib/word_list_query.dart
@@ -8,6 +8,12 @@ enum SortType { id, importance, lastReviewed }
 /// Additional filters when fetching words.
 enum WordFilter { unviewed, wrongOnly }
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Global provider storing the current [WordListQuery].
+final currentQueryProvider =
+    StateProvider<WordListQuery>((ref) => const WordListQuery());
+
 /// Query used by [FlashcardRepository.fetch] to obtain filtered words.
 class WordListQuery {
   /// Text used to search `term` or `reading` fields.
@@ -37,5 +43,44 @@ class WordListQuery {
       sort: sort ?? this.sort,
       filters: filters ?? this.filters,
     );
+  }
+
+  /// Apply this query to [cards], returning a filtered and sorted list.
+  List<Flashcard> apply(List<Flashcard> cards) {
+    final q = searchText.trim().toLowerCase();
+    final filtered = cards.where((card) {
+      final matchesQuery = q.isEmpty ||
+          card.term.toLowerCase().contains(q) ||
+          card.reading.toLowerCase().contains(q);
+      bool passesFilter = true;
+      if (filters.contains(WordFilter.unviewed)) {
+        passesFilter &= card.lastReviewed == null;
+      }
+      if (filters.contains(WordFilter.wrongOnly)) {
+        passesFilter &= card.wrongCount > 0;
+      }
+      return matchesQuery && passesFilter;
+    }).toList();
+
+    switch (sort) {
+      case SortType.id:
+        filtered.sort((a, b) => a.id.compareTo(b.id));
+        break;
+      case SortType.importance:
+        filtered.sort((a, b) => b.importance.compareTo(a.importance));
+        break;
+      case SortType.lastReviewed:
+        filtered.sort((a, b) {
+          final at = a.lastReviewed;
+          final bt = b.lastReviewed;
+          if (at == null && bt == null) return 0;
+          if (at == null) return 1;
+          if (bt == null) return -1;
+          return bt.compareTo(at);
+        });
+        break;
+    }
+
+    return filtered;
   }
 }

--- a/lib/word_query_sheet.dart
+++ b/lib/word_query_sheet.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+
+import 'word_list_query.dart';
+
+/// Bottom sheet widget for editing [WordListQuery].
+class WordQuerySheet extends StatefulWidget {
+  final WordListQuery initial;
+  const WordQuerySheet({Key? key, required this.initial}) : super(key: key);
+
+  @override
+  State<WordQuerySheet> createState() => _WordQuerySheetState();
+}
+
+class _WordQuerySheetState extends State<WordQuerySheet> {
+  late TextEditingController _controller;
+  late SortType _sort;
+  late Set<WordFilter> _filters;
+
+  @override
+  void initState() {
+    super.initState();
+    _sort = widget.initial.sort;
+    _filters = {...widget.initial.filters};
+    _controller = TextEditingController(text: widget.initial.searchText);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  String _labelForSort(SortType type) {
+    switch (type) {
+      case SortType.id:
+        return 'ID順';
+      case SortType.importance:
+        return '重要度順';
+      case SortType.lastReviewed:
+        return '最終閲覧順';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: TextField(
+                  controller: _controller,
+                  decoration: const InputDecoration(
+                    labelText: '検索語',
+                    prefixIcon: Icon(Icons.search),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Column(
+                  children: SortType.values
+                      .map(
+                        (m) => RadioListTile<SortType>(
+                          title: Text(_labelForSort(m)),
+                          value: m,
+                          groupValue: _sort,
+                          onChanged: (v) => setState(() {
+                            if (v != null) _sort = v;
+                          }),
+                        ),
+                      )
+                      .toList(),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Wrap(
+                  spacing: 8,
+                  children: [
+                    FilterChip(
+                      label: const Text('未閲覧'),
+                      selected: _filters.contains(WordFilter.unviewed),
+                      onSelected: (val) {
+                        setState(() {
+                          if (val) {
+                            _filters.add(WordFilter.unviewed);
+                          } else {
+                            _filters.remove(WordFilter.unviewed);
+                          }
+                        });
+                      },
+                    ),
+                    FilterChip(
+                      label: const Text('間違えのみ'),
+                      selected: _filters.contains(WordFilter.wrongOnly),
+                      onSelected: (val) {
+                        setState(() {
+                          if (val) {
+                            _filters.add(WordFilter.wrongOnly);
+                          } else {
+                            _filters.remove(WordFilter.wrongOnly);
+                          }
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    ElevatedButton(
+                      onPressed: () {
+                        Navigator.of(context).pop(
+                          widget.initial.copyWith(
+                            searchText: _controller.text,
+                            sort: _sort,
+                            filters: _filters,
+                          ),
+                        );
+                      },
+                      child: const Text('適用'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Show a [WordQuerySheet] and return the updated [WordListQuery].
+Future<WordListQuery?> showWordQuerySheet(
+    BuildContext context, WordListQuery current) {
+  return showModalBottomSheet<WordListQuery>(
+    context: context,
+    isScrollControlled: true,
+    builder: (ctx) => WordQuerySheet(initial: current),
+  );
+}


### PR DESCRIPTION
## Summary
- implement `WordListQuery.apply` to filter and sort flashcards
- use new method within `FlashcardRepository.fetch`
- apply query in `WordListTabContent`
- share the word query across tabs via `currentQueryProvider`
- add reusable `WordQuerySheet` bottom sheet widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685883d9161c832a977a41a7df0f6b15