### PR TITLE
Add missing flashcard model import

### DIFF
--- a/lib/word_list_query.dart
+++ b/lib/word_list_query.dart
@@ -10,6 +10,8 @@ enum WordFilter { unviewed, wrongOnly }
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'flashcard_model.dart';
+
 /// Global provider storing the current [WordListQuery].
 final currentQueryProvider =
     StateProvider<WordListQuery>((ref) => const WordListQuery());


### PR DESCRIPTION
## Summary
- import `flashcard_model.dart` in `word_list_query.dart`

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685904cc11e8832ab4a168dae494e281