### PR TITLE
Remove unused viewedIds calc

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -92,8 +92,6 @@ class FlashcardRepository {
     final historyBox = Hive.box<HistoryEntry>(historyBoxName);
     final quizStatsBox = Hive.box<Map>(quizStatsBoxName);
 
-    final viewedIds = historyBox.values.map((e) => e.wordId).toSet();
-
     final Map<String, int> wrongCounts = {};
     for (final m in quizStatsBox.values) {
       final ids = (m['wordIds'] as List?)?.cast<String>() ?? [];


### PR DESCRIPTION
## Summary
- tidy `FlashcardRepository.fetch` by removing an unused `viewedIds` variable

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590cc406a4832a8e25600c2a3aab13