### PR TITLE
Fix import order to restore Flutter web build

### DIFF
--- a/lib/word_list_query.dart
+++ b/lib/word_list_query.dart
@@ -2,15 +2,15 @@
 ///
 /// Includes sorting, filtering and search text.
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'flashcard_model.dart';
+
 /// Sorting options for word lists.
 enum SortType { id, importance, lastReviewed }
 
 /// Additional filters when fetching words.
 enum WordFilter { unviewed, wrongOnly }
-
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'flashcard_model.dart';
 
 /// Global provider storing the current [WordListQuery].
 final currentQueryProvider =


### PR DESCRIPTION
## Summary
- fix error `Directives must appear before any declarations` by moving imports above enum declarations

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685921514a38832aab6f21ec559f78e9