### PR TITLE
Implement SortType label extension

### DIFF
--- a/lib/sort_type_ext.dart
+++ b/lib/sort_type_ext.dart
@@ -1,0 +1,14 @@
+import 'word_list_query.dart';
+
+extension SortTypeExt on SortType {
+  String get label {
+    switch (this) {
+      case SortType.id:
+        return 'ID順';
+      case SortType.importance:
+        return '重要度順';
+      case SortType.lastReviewed:
+        return '最終閲覧順';
+    }
+  }
+}

--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -77,16 +77,6 @@ class WordListTabContentState extends ConsumerState<WordListTabContent> {
     );
   }
 
-  String _labelForSort(SortType type) {
-    switch (type) {
-      case SortType.id:
-        return 'ID順';
-      case SortType.importance:
-        return '重要度順';
-      case SortType.lastReviewed:
-        return '最終閲覧順';
-    }
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/word_query_sheet.dart
+++ b/lib/word_query_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'word_list_query.dart';
+import 'sort_type_ext.dart';
 
 /// Bottom sheet widget for editing [WordListQuery].
 class WordQuerySheet extends StatefulWidget {
@@ -30,16 +31,6 @@ class _WordQuerySheetState extends State<WordQuerySheet> {
     super.dispose();
   }
 
-  String _labelForSort(SortType type) {
-    switch (type) {
-      case SortType.id:
-        return 'ID順';
-      case SortType.importance:
-        return '重要度順';
-      case SortType.lastReviewed:
-        return '最終閲覧順';
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -67,7 +58,7 @@ class _WordQuerySheetState extends State<WordQuerySheet> {
                   children: SortType.values
                       .map(
                         (m) => RadioListTile<SortType>(
-                          title: Text(_labelForSort(m)),
+                          title: Text(m.label),
                           value: m,
                           groupValue: _sort,
                           onChanged: (v) => setState(() {


### PR DESCRIPTION
## Summary
- add a `SortTypeExt` extension to centralize labels
- use `SortTypeExt.label` from `WordQuerySheet`
- remove unused code in `WordListTabContent`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*
- `flutter build web --base-href /tango/ --pwa-strategy=none` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68592397ca88832aa5dbe4d8418530fe