### PR TITLE
Fix word list reload

### DIFF
--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -26,11 +26,13 @@ class WordListTabContent extends ConsumerStatefulWidget {
 }
 
 class WordListTabContentState extends ConsumerState<WordListTabContent> {
+  late final Future<List<Flashcard>> _allWordsFuture;
   @override
   void initState() {
     super.initState();
     // Load initial list with default review mode.
     Future(() => updateMode(ReviewMode.random));
+    _allWordsFuture = FlashcardRepository.loadAll();
   }
 
   /// Show bottom sheet to edit the current [WordListQuery].
@@ -82,8 +84,8 @@ class WordListTabContentState extends ConsumerState<WordListTabContent> {
   Widget build(BuildContext context) {
     final words = ref.watch(wordListForModeProvider);
     final query = ref.watch(currentQueryProvider);
-    return FutureBuilder<List<Flashcard>>( 
-      future: FlashcardRepository.loadAll(),
+    return FutureBuilder<List<Flashcard>>(
+      future: _allWordsFuture,
       builder: (context, snapshot) {
         if (!snapshot.hasData || words == null) {
           return const Center(child: CircularProgressIndicator());


### PR DESCRIPTION
## Summary
- avoid rebuilding FlashcardRepository future in word list tab

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596a7c4f5c832a9a3d45208493c31b