### PR TITLE
Refactor review mode labels

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -15,6 +15,7 @@ import 'learning_history_detail_screen.dart';
 import 'about_screen.dart';
 import 'today_summary_screen.dart';
 import 'review_service.dart';
+import 'review_mode_ext.dart';
 import 'word_detail_content.dart'; // 詳細表示用コンテンツウィジェット
 import 'word_detail_controller.dart';
 
@@ -211,26 +212,7 @@ class _MainScreenState extends State<MainScreen> {
         .withOpacity(0.2);
   }
 
-  String _labelForMode(ReviewMode mode) {
-    switch (mode) {
-      case ReviewMode.newWords:
-        return '新出語';
-      case ReviewMode.random:
-        return 'ランダム';
-      case ReviewMode.wrongDescending:
-        return '間違え順';
-      case ReviewMode.tagFocus:
-        return 'タグ集中';
-      case ReviewMode.spacedRepetition:
-        return '復習間隔順';
-      case ReviewMode.mixed:
-        return '総合優先度';
-      case ReviewMode.tagOnly:
-        return 'タグのみ';
-      case ReviewMode.autoFilter:
-        return '🌀 自動フィルターモード';
-    }
-  }
+
 
   Widget _buildActiveIcon(IconData icon, BuildContext context, int itemIndex) {
     bool isSelected = (_bottomNavIndex == itemIndex);
@@ -346,7 +328,7 @@ class _MainScreenState extends State<MainScreen> {
                 items: ReviewMode.values
                     .map((m) => DropdownMenuItem(
                           value: m,
-                          child: Text(_labelForMode(m)),
+                          child: Text(m.label),
                         ))
                     .toList(),
               ),

--- a/lib/quiz_setup_screen.dart
+++ b/lib/quiz_setup_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'flashcard_model.dart';
 import 'review_service.dart';
+import 'review_mode_ext.dart';
 import 'quiz_in_progress_screen.dart';
 
 // Quiz type options
@@ -132,47 +133,21 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
       children: [
         Text('出題モード', style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 8),
-        RadioListTile<ReviewMode>(
-          title: const Text('新出語'),
-          value: ReviewMode.newWords,
-          groupValue: _mode,
-          onChanged: (v) => setState(() => _mode = v!),
-        ),
-        RadioListTile<ReviewMode>(
-          title: const Text('ランダム'),
-          value: ReviewMode.random,
-          groupValue: _mode,
-          onChanged: (v) => setState(() => _mode = v!),
-        ),
-        RadioListTile<ReviewMode>(
-          title: const Text('間違え順'),
-          value: ReviewMode.wrongDescending,
-          groupValue: _mode,
-          onChanged: (v) => setState(() => _mode = v!),
-        ),
-        RadioListTile<ReviewMode>(
-          title: const Text('タグ集中'),
-          value: ReviewMode.tagFocus,
-          groupValue: _mode,
-          onChanged: (v) => setState(() => _mode = v!),
-        ),
-        RadioListTile<ReviewMode>(
-          title: const Text('復習間隔順'),
-          value: ReviewMode.spacedRepetition,
-          groupValue: _mode,
-          onChanged: (v) => setState(() => _mode = v!),
-        ),
-        RadioListTile<ReviewMode>(
-          title: const Text('総合優先度'),
-          value: ReviewMode.mixed,
-          groupValue: _mode,
-          onChanged: (v) => setState(() => _mode = v!),
-        ),
-        RadioListTile<ReviewMode>(
-          title: const Text('タグのみ'),
-          value: ReviewMode.tagOnly,
-          groupValue: _mode,
-          onChanged: (v) => setState(() => _mode = v!),
+        ...[
+          ReviewMode.newWords,
+          ReviewMode.random,
+          ReviewMode.wrongDescending,
+          ReviewMode.tagFocus,
+          ReviewMode.spacedRepetition,
+          ReviewMode.mixed,
+          ReviewMode.tagOnly,
+        ].map(
+          (mode) => RadioListTile<ReviewMode>(
+            title: Text(mode.label),
+            value: mode,
+            groupValue: _mode,
+            onChanged: (v) => setState(() => _mode = v!),
+          ),
         ),
         const SizedBox(height: 24),
         Text('星フィルタ', style: Theme.of(context).textTheme.titleLarge),

--- a/lib/review_mode_ext.dart
+++ b/lib/review_mode_ext.dart
@@ -1,0 +1,24 @@
+import 'review_service.dart';
+
+extension ReviewModeExt on ReviewMode {
+  String get label {
+    switch (this) {
+      case ReviewMode.newWords:
+        return '新出語';
+      case ReviewMode.random:
+        return 'ランダム';
+      case ReviewMode.wrongDescending:
+        return '間違え順';
+      case ReviewMode.tagFocus:
+        return 'タグ集中';
+      case ReviewMode.spacedRepetition:
+        return '復習間隔順';
+      case ReviewMode.mixed:
+        return '総合優先度';
+      case ReviewMode.tagOnly:
+        return 'タグのみ';
+      case ReviewMode.autoFilter:
+        return '🌀 自動フィルターモード';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- factor out `ReviewModeExt` to centralize labels
- update `MainScreen` and `QuizSetupScreen` to use the new extension

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596b899308832a864d325a0ab71d38