### PR TITLE
Add CI for Flutter tests

### DIFF
--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -1,0 +1,23 @@
+name: Flutter Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.32.0
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Format check
+        run: dart format --set-exit-if-changed .
+      - name: Run tests
+        run: flutter test --coverage

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## チェックリスト
+- [ ] テスト書いた？
+- [ ] `flutter analyze` は通った？
+- [ ] `flutter test` は通った？

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -248,6 +248,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   hive_generator: ^2.0.1 # Hiveオブジェクトを生成するために必要
   build_runner: ^2.4.0   # コードジェネレータを実行するために必要
   # The "flutter_lints" package below contains a set of recommended lints to

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Run Flutter tests with coverage
+fvm flutter test --coverage

--- a/test/sample_test.dart
+++ b/test/sample_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('sanity check', () {
+    expect(2 + 2, 4);
+  });
+}


### PR DESCRIPTION
## Summary
- add sample test
- add integration_test as a dev dependency
- provide script to run flutter tests with coverage
- run flutter test in GitHub Actions
- add PR checklist asking about tests

## Testing
- `dart format --set-exit-if-changed .` *(fails: `dart` not found)*
- `flutter analyze` *(fails: `flutter` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e02289cc832a833dd0f2453f8bc7