### PR TITLE
Refactor quiz star handling

### DIFF
--- a/lib/quiz_in_progress_screen.dart
+++ b/lib/quiz_in_progress_screen.dart
@@ -6,6 +6,7 @@ import 'flashcard_model.dart';
 import 'flashcard_repository.dart';
 import 'quiz_setup_screen.dart';
 import 'quiz_result_screen.dart';
+import 'star_color.dart';
 
 const String favoritesBoxName = 'favorites_box_v2';
 
@@ -37,7 +38,7 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
   bool _answered = false;
   String? _selectedTerm;
 
-  final Map<String, Map<String, bool>> _favoriteStatusMap = {};
+  final Map<String, Map<StarColor, bool>> _favoriteStatusMap = {};
   late DateTime _startTime;
 
   @override
@@ -57,26 +58,25 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
 
   void _loadFavoriteStatus(String wordId) {
     if (_favoriteStatusMap.containsKey(wordId)) return;
-    Map<String, bool> status = {
-      'red': false,
-      'yellow': false,
-      'blue': false,
+    final status = {
+      for (final c in StarColor.values) c: false,
     };
     final raw = _favoritesBox.get(wordId);
     if (raw != null) {
       final stored = raw.map((k, v) => MapEntry(k.toString(), v as bool));
-      status['red'] = stored['red'] ?? false;
-      status['yellow'] = stored['yellow'] ?? false;
-      status['blue'] = stored['blue'] ?? false;
+      status[StarColor.red] = stored['red'] ?? false;
+      status[StarColor.yellow] = stored['yellow'] ?? false;
+      status[StarColor.blue] = stored['blue'] ?? false;
     }
     _favoriteStatusMap[wordId] = status;
   }
 
-  Future<void> _toggleFavorite(String wordId, String colorKey) async {
+  Future<void> _toggleFavorite(String wordId, StarColor colorKey) async {
     _loadFavoriteStatus(wordId);
-    final current = Map<String, bool>.from(_favoriteStatusMap[wordId]!);
+    final current = Map<StarColor, bool>.from(_favoriteStatusMap[wordId]!);
     current[colorKey] = !(current[colorKey] ?? false);
-    await _favoritesBox.put(wordId, Map<String, dynamic>.from(current));
+    await _favoritesBox.put(wordId,
+        {for (final e in current.entries) e.key.name: e.value});
     if (!mounted) return;
     setState(() {
       _favoriteStatusMap[wordId] = current;
@@ -165,12 +165,9 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
     }
   }
 
-  Widget _buildStarIcon(String wordId, String colorKey, Color color) {
-    final status = _favoriteStatusMap[wordId] ?? {
-      'red': false,
-      'yellow': false,
-      'blue': false,
-    };
+  Widget _buildStarIcon(String wordId, StarColor colorKey, Color color) {
+    final status = _favoriteStatusMap[wordId] ??
+        {for (final c in StarColor.values) c: false};
     bool isFavorite = status[colorKey] ?? false;
     return IconButton(
       icon: Icon(
@@ -180,11 +177,7 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
         size: 24,
       ),
       onPressed: () => _toggleFavorite(wordId, colorKey),
-      tooltip: colorKey == 'red'
-          ? '赤星'
-          : colorKey == 'yellow'
-              ? '黄星'
-              : '青星',
+      tooltip: '${colorKey.label}星',
     );
   }
 
@@ -226,11 +219,11 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               _buildStarIcon(
-                  _currentFlashcard.id, 'red', Theme.of(context).colorScheme.error),
-              _buildStarIcon(_currentFlashcard.id, 'yellow',
+                  _currentFlashcard.id, StarColor.red, Theme.of(context).colorScheme.error),
+              _buildStarIcon(_currentFlashcard.id, StarColor.yellow,
                   Theme.of(context).colorScheme.secondary),
               _buildStarIcon(
-                  _currentFlashcard.id, 'blue', Theme.of(context).colorScheme.primary),
+                  _currentFlashcard.id, StarColor.blue, Theme.of(context).colorScheme.primary),
             ],
           ),
         ] else ...[
@@ -260,13 +253,13 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
                                   _buildStarIcon(
-                                      c.id, 'red', Theme.of(context).colorScheme.error),
+                                      c.id, StarColor.red, Theme.of(context).colorScheme.error),
                                   _buildStarIcon(
                                       c.id,
-                                      'yellow',
+                                      StarColor.yellow,
                                       Theme.of(context).colorScheme.secondary),
                                   _buildStarIcon(
-                                      c.id, 'blue', Theme.of(context).colorScheme.primary),
+                                      c.id, StarColor.blue, Theme.of(context).colorScheme.primary),
                                 ],
                               ),
                             ],

--- a/lib/quiz_setup_screen.dart
+++ b/lib/quiz_setup_screen.dart
@@ -4,6 +4,7 @@ import 'flashcard_model.dart';
 import 'review_service.dart';
 import 'review_mode_ext.dart';
 import 'quiz_in_progress_screen.dart';
+import 'star_color.dart';
 
 // Quiz type options
 enum QuizType { multipleChoice, flashcard }
@@ -25,10 +26,10 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
   int _questionCount = 10;
   bool _loadingCount = false;
   String? _countError;
-  final Map<String, bool> _starFilter = {
-    'red': true,
-    'yellow': true,
-    'blue': true,
+  final Map<StarColor, bool> _starFilter = {
+    StarColor.red: true,
+    StarColor.yellow: true,
+    StarColor.blue: true,
   };
 
   @override
@@ -103,24 +104,20 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     );
   }
 
-  Widget _buildStarCheckbox(String key, Color color) {
+  Widget _buildStarCheckbox(StarColor colorKey, Color color) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         Checkbox(
-          value: _starFilter[key],
+          value: _starFilter[colorKey],
           onChanged: (val) {
             setState(() {
-              _starFilter[key] = val ?? false;
+              _starFilter[colorKey] = val ?? false;
             });
           },
           activeColor: color,
         ),
-        Text(key == 'red'
-            ? '赤'
-            : key == 'yellow'
-                ? '黄'
-                : '青'),
+        Text(colorKey.label),
         const SizedBox(width: 8),
       ],
     );
@@ -154,10 +151,12 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
         const SizedBox(height: 8),
         Row(
           children: [
-            _buildStarCheckbox('red', Theme.of(context).colorScheme.error),
             _buildStarCheckbox(
-                'yellow', Theme.of(context).colorScheme.secondary),
-            _buildStarCheckbox('blue', Theme.of(context).colorScheme.primary),
+                StarColor.red, Theme.of(context).colorScheme.error),
+            _buildStarCheckbox(
+                StarColor.yellow, Theme.of(context).colorScheme.secondary),
+            _buildStarCheckbox(
+                StarColor.blue, Theme.of(context).colorScheme.primary),
           ],
         ),
         const SizedBox(height: 24),
@@ -167,23 +166,12 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
           children: [
             DropdownButton<int>(
               value: _questionCount,
-              items: const [
-                10,
-                20,
-                30,
-                40,
-                50,
-                100,
-                200,
-                300,
-                400,
-                500,
-                600,
-                700,
-                800
+              items: [
+                ...List.generate(5, (i) => (i + 1) * 10),
+                ...List.generate(8, (i) => (i + 1) * 100),
               ]
-                  .map((e) => DropdownMenuItem<int>(
-                      value: e, child: Text(e.toString())))
+                  .map((e) =>
+                      DropdownMenuItem<int>(value: e, child: Text(e.toString())))
                   .toList(),
               onChanged: (v) {
                 if (v != null) {

--- a/lib/star_color.dart
+++ b/lib/star_color.dart
@@ -1,0 +1,14 @@
+enum StarColor { red, yellow, blue }
+
+extension StarColorExt on StarColor {
+  String get label {
+    switch (this) {
+      case StarColor.red:
+        return '赤';
+      case StarColor.yellow:
+        return '黄';
+      case StarColor.blue:
+        return '青';
+    }
+  }
+}

--- a/lib/tabs_content/favorites_tab_content.dart
+++ b/lib/tabs_content/favorites_tab_content.dart
@@ -5,6 +5,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import '../flashcard_model.dart';
 import '../app_view.dart';
 import '../flashcard_repository.dart';
+import '../star_color.dart';
 
 const String favoritesBoxName = 'favorites_box_v2';
 
@@ -23,7 +24,7 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
   List<Flashcard> _allFlashcards = [];
   bool _isInitialLoading = true;
   String? _initialError;
-  final Set<String> _activeFilters = {};
+  final Set<StarColor> _activeFilters = {};
   bool _useAndFilter = true; // true: AND, false: OR
 
   @override
@@ -65,15 +66,15 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
         favoriteStatusRaw.map((k, v) => MapEntry(k.toString(), v as bool));
 
     List<Widget> stars = [];
-    if (favoriteStatus['red'] == true) {
+    if (favoriteStatus[StarColor.red.name] == true) {
       stars.add(Icon(Icons.star,
           color: Theme.of(context).colorScheme.error, size: 16));
     }
-    if (favoriteStatus['yellow'] == true) {
+    if (favoriteStatus[StarColor.yellow.name] == true) {
       stars.add(Icon(Icons.star,
           color: Theme.of(context).colorScheme.secondary, size: 16));
     }
-    if (favoriteStatus['blue'] == true) {
+    if (favoriteStatus[StarColor.blue.name] == true) {
       stars.add(Icon(Icons.star,
           color: Theme.of(context).colorScheme.primary, size: 16));
     }
@@ -81,7 +82,7 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
     return Row(mainAxisSize: MainAxisSize.min, children: stars);
   }
 
-  void _toggleFilter(String colorKey) {
+  void _toggleFilter(StarColor colorKey) {
     setState(() {
       if (_activeFilters.contains(colorKey)) {
         _activeFilters.remove(colorKey);
@@ -91,7 +92,7 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
     });
   }
 
-  Widget _buildFilterStar(String colorKey, Color color) {
+  Widget _buildFilterStar(StarColor colorKey, Color color) {
     final bool isSelected = _activeFilters.contains(colorKey);
     return IconButton(
       icon: Icon(
@@ -100,26 +101,23 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
         size: 24,
       ),
       onPressed: () => _toggleFilter(colorKey),
-      tooltip: '${colorKey == 'red' ? '赤' : colorKey == 'yellow' ? '黄' : '青'}星で絞り込む',
+      tooltip: '${colorKey == StarColor.red ? '赤' : colorKey == StarColor.yellow ? '黄' : '青'}星で絞り込む',
     );
   }
 
   bool _passesFilter(Map<String, bool> status) {
     if (_activeFilters.isEmpty) {
-      return status['red'] == true || status['yellow'] == true || status['blue'] == true;
+      return status.values.any((v) => v == true);
     }
-    // Collect the set of colors that are actually starred for this word
     final wordStars = status.entries
         .where((entry) => entry.value == true)
-        .map((entry) => entry.key)
+        .map((entry) => StarColor.values.firstWhere((c) => c.name == entry.key))
         .toSet();
 
     if (_useAndFilter) {
-      // AND mode: show only when the starred colors exactly match the filters
       return wordStars.length == _activeFilters.length &&
           wordStars.every((color) => _activeFilters.contains(color));
     } else {
-      // OR mode: show when any of the starred colors match a filter
       return wordStars.any((color) => _activeFilters.contains(color));
     }
   }
@@ -272,11 +270,11 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
                   ),
                   const SizedBox(width: 8),
                   _buildFilterStar(
-                      'red', Theme.of(context).colorScheme.error),
+                      StarColor.red, Theme.of(context).colorScheme.error),
                   _buildFilterStar(
-                      'yellow', Theme.of(context).colorScheme.secondary),
+                      StarColor.yellow, Theme.of(context).colorScheme.secondary),
                   _buildFilterStar(
-                      'blue', Theme.of(context).colorScheme.primary),
+                      StarColor.blue, Theme.of(context).colorScheme.primary),
                 ],
               ),
             ),

--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -6,6 +6,7 @@ import 'flashcard_model.dart';
 import '../history_entry_model.dart'; // 閲覧履歴用のモデルをインポート (libフォルダ直下にある想定)
 import '../word_detail_controller.dart';
 import 'flashcard_repository.dart';
+import '../star_color.dart';
 
 // Box名は他のファイルと共通にするため定数化
 const String favoritesBoxName = 'favorites_box_v2';
@@ -51,10 +52,10 @@ class _WordDetailContentState extends State<WordDetailContent> {
   Flashcard get _currentFlashcard => _currentWord;
 
   // お気に入り状態のローカル管理用 (これは変更なし)
-  Map<String, bool> _favoriteStatus = {
-    'red': false,
-    'yellow': false,
-    'blue': false,
+  Map<StarColor, bool> _favoriteStatus = {
+    StarColor.red: false,
+    StarColor.yellow: false,
+    StarColor.blue: false,
   };
 
   @override
@@ -102,27 +103,28 @@ class _WordDetailContentState extends State<WordDetailContent> {
 
         if (!mounted) return;
         setState(() {
-          _favoriteStatus['red'] = storedStatus['red'] ?? false;
-          _favoriteStatus['yellow'] = storedStatus['yellow'] ?? false;
-          _favoriteStatus['blue'] = storedStatus['blue'] ?? false;
+          _favoriteStatus[StarColor.red] = storedStatus['red'] ?? false;
+          _favoriteStatus[StarColor.yellow] = storedStatus['yellow'] ?? false;
+          _favoriteStatus[StarColor.blue] = storedStatus['blue'] ?? false;
         });
       }
     } else {
       if (!mounted) return;
       setState(() {
-        _favoriteStatus['red'] = false;
-        _favoriteStatus['yellow'] = false;
-        _favoriteStatus['blue'] = false;
+        _favoriteStatus[StarColor.red] = false;
+        _favoriteStatus[StarColor.yellow] = false;
+        _favoriteStatus[StarColor.blue] = false;
       });
     }
   }
 
   // 既存：星のON/OFFを切り替え、Hiveにお気に入り状態を保存するメソッド (変更なし)
-  Future<void> _toggleFavorite(String colorKey) async {
+  Future<void> _toggleFavorite(StarColor colorKey) async {
     final String wordId = _displayFlashcards[_currentIndex].id;
-    Map<String, bool> currentStatus = Map<String, bool>.from(_favoriteStatus);
+    Map<StarColor, bool> currentStatus = Map<StarColor, bool>.from(_favoriteStatus);
     currentStatus[colorKey] = !currentStatus[colorKey]!;
-    await _favoritesBox.put(wordId, Map<String, dynamic>.from(currentStatus));
+    await _favoritesBox.put(
+        wordId, {for (final e in currentStatus.entries) e.key.name: e.value});
     if (!mounted) return;
     setState(() {
       _favoriteStatus = currentStatus;
@@ -243,7 +245,7 @@ class _WordDetailContentState extends State<WordDetailContent> {
   }
 
   // 既存：星アイコンを生成するウィジェットメソッド (変更なし)
-  Widget _buildStarIcon(String colorKey, Color color) {
+  Widget _buildStarIcon(StarColor colorKey, Color color) {
     bool isFavorite = _favoriteStatus[colorKey] ?? false;
     return IconButton(
       icon: Icon(
@@ -252,9 +254,9 @@ class _WordDetailContentState extends State<WordDetailContent> {
         size: 28,
       ),
       onPressed: () => _toggleFavorite(colorKey),
-      tooltip: colorKey == 'red'
+      tooltip: colorKey == StarColor.red
           ? '赤星'
-          : colorKey == 'yellow'
+          : colorKey == StarColor.yellow
               ? '黄星'
               : '青星',
     );
@@ -448,10 +450,10 @@ class _WordDetailContentState extends State<WordDetailContent> {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _buildStarIcon('red', Theme.of(context).colorScheme.error),
+                  _buildStarIcon(StarColor.red, Theme.of(context).colorScheme.error),
                   _buildStarIcon(
-                      'yellow', Theme.of(context).colorScheme.secondary),
-                  _buildStarIcon('blue', Theme.of(context).colorScheme.primary),
+                      StarColor.yellow, Theme.of(context).colorScheme.secondary),
+                  _buildStarIcon(StarColor.blue, Theme.of(context).colorScheme.primary),
                 ],
               ),
             ],

--- a/lib/word_detail_screen.dart
+++ b/lib/word_detail_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'flashcard_model.dart'; // 作成したFlashcardモデルをインポート
 import 'package:hive/hive.dart';
+import 'star_color.dart';
 
 const String favoritesBoxName = 'favorites_box_v2';
 
@@ -17,10 +18,10 @@ class WordDetailScreen extends StatefulWidget {
 
 class _WordDetailScreenState extends State<WordDetailScreen> {
   late Box<Map> _favoritesBox;
-  Map<String, bool> _favoriteStatus = {
-    'red': false,
-    'yellow': false,
-    'blue': false,
+  Map<StarColor, bool> _favoriteStatus = {
+    StarColor.red: false,
+    StarColor.yellow: false,
+    StarColor.blue: false,
   };
 
   @override
@@ -36,25 +37,25 @@ class _WordDetailScreenState extends State<WordDetailScreen> {
       final stored = _favoritesBox.get(id);
       if (stored != null) {
         setState(() {
-          _favoriteStatus['red'] = stored['red'] as bool? ?? false;
-          _favoriteStatus['yellow'] = stored['yellow'] as bool? ?? false;
-          _favoriteStatus['blue'] = stored['blue'] as bool? ?? false;
+          _favoriteStatus[StarColor.red] = stored['red'] as bool? ?? false;
+          _favoriteStatus[StarColor.yellow] = stored['yellow'] as bool? ?? false;
+          _favoriteStatus[StarColor.blue] = stored['blue'] as bool? ?? false;
         });
       }
     }
   }
 
-  Future<void> _toggleFavorite(String colorKey) async {
+  Future<void> _toggleFavorite(StarColor colorKey) async {
     setState(() {
       _favoriteStatus[colorKey] = !_favoriteStatus[colorKey]!;
     });
     await _favoritesBox.put(
       widget.flashcard.id,
-      Map<String, dynamic>.from(_favoriteStatus),
+      {for (final e in _favoriteStatus.entries) e.key.name: e.value},
     );
   }
 
-  Widget _buildStarIcon(String colorKey, Color color) {
+  Widget _buildStarIcon(StarColor colorKey, Color color) {
     bool isFavorite = _favoriteStatus[colorKey]!;
     return IconButton(
       icon: Icon(
@@ -64,9 +65,9 @@ class _WordDetailScreenState extends State<WordDetailScreen> {
         size: 28, // アイコンサイズ調整
       ),
       onPressed: () => _toggleFavorite(colorKey),
-      tooltip: colorKey == 'red'
+      tooltip: colorKey == StarColor.red
           ? '赤星 (未学習など)'
-          : colorKey == 'yellow'
+          : colorKey == StarColor.yellow
               ? '黄星 (自信なしなど)'
               : '青星 (習得済みなど)', // ツールチップで色の意味を示唆
     );
@@ -158,10 +159,12 @@ class _WordDetailScreenState extends State<WordDetailScreen> {
                 Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    _buildStarIcon('red', Theme.of(context).colorScheme.error),
                     _buildStarIcon(
-                        'yellow', Theme.of(context).colorScheme.secondary),
-                    _buildStarIcon('blue', Theme.of(context).colorScheme.primary),
+                        StarColor.red, Theme.of(context).colorScheme.error),
+                    _buildStarIcon(
+                        StarColor.yellow, Theme.of(context).colorScheme.secondary),
+                    _buildStarIcon(
+                        StarColor.blue, Theme.of(context).colorScheme.primary),
                   ],
                 ),
               ],


### PR DESCRIPTION
## Why
- quiz screens duplicated star color strings
- dropdown options were hand written

## What
- add `StarColor` enum
- replace color string maps with enum keys
- generate question counts programmatically

## How
- `dart format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4daef6dc832ab0a4c3f20b6b62b1