### PR TITLE
Fix missing HistoryService import

### DIFF
--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -8,6 +8,7 @@ import '../word_detail_controller.dart';
 import 'flashcard_repository.dart';
 import '../star_color.dart';
 import '../constants.dart';
+import 'services/history_service.dart';
 
 class _ViewState {
   final List<Flashcard> list;


### PR DESCRIPTION
## Summary
- fix missing `HistoryService` import so word details compile

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685a95bc9ce4832a82469e48ec3b5f4a