### PR TITLE
Feat: simplify word list app bar

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -20,7 +20,8 @@ import 'review_mode_ext.dart';
 import 'word_detail_content.dart'; // 詳細表示用コンテンツウィジェット
 import 'word_detail_controller.dart';
 import 'word_list_query.dart';
-import 'package:badges/badges.dart' as badges;
+import 'sort_type_ext.dart';
+import 'overflow_menu.dart';
 
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -256,8 +257,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
     final query = ref.watch(currentQueryProvider);
     final filtered =
         words != null ? query.apply(words) : <Flashcard>[];
-    final hasChips =
-        query.searchText.isNotEmpty || query.filters.isNotEmpty;
 
     bool canGoBack = _currentScreen == AppScreen.wordDetail ||
         _currentScreen == AppScreen.settings ||
@@ -280,17 +279,38 @@ class _MainScreenState extends ConsumerState<MainScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: AnimatedBuilder(
-          animation: _detailController,
-          builder: (context, _) {
-            final baseTitle = _getAppBarTitle();
-            if (_currentScreen == AppScreen.wordList && words != null) {
-              return Text(
-                  '$baseTitle (${filtered.length} / ${words.length} 件)');
-            }
-            return Text(baseTitle);
-          },
-        ),
+        title: _currentScreen == AppScreen.wordList
+            ? PopupMenuButton<SortType>(
+                initialValue: query.sort,
+                onSelected: (v) {
+                  ref.read(currentQueryProvider.notifier).state =
+                      query.copyWith(sort: v);
+                },
+                itemBuilder: (context) => SortType.values
+                    .map((m) => PopupMenuItem(
+                          value: m,
+                          child: Text(m.label),
+                        ))
+                    .toList(),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(query.sort.label),
+                    const Icon(Icons.arrow_drop_down),
+                  ],
+                ),
+              )
+            : AnimatedBuilder(
+                animation: _detailController,
+                builder: (context, _) {
+                  final baseTitle = _getAppBarTitle();
+                  if (_currentScreen == AppScreen.wordList && words != null) {
+                    return Text(
+                        '$baseTitle (${filtered.length} / ${words.length} 件)');
+                  }
+                  return Text(baseTitle);
+                },
+              ),
         leadingWidth: _currentScreen == AppScreen.wordDetail ? 96 : null,
         leading: _currentScreen == AppScreen.wordDetail
             ? AnimatedBuilder(
@@ -327,54 +347,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
                     },
                   )
                 : null),
-        bottom: _currentScreen == AppScreen.wordList
-            ? PreferredSize(
-                preferredSize:
-                    Size.fromHeight(hasChips ? 40 : 0),
-                child: hasChips
-                    ? Padding(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 8, vertical: 4),
-                        child: Wrap(
-                          spacing: 4,
-                          children: [
-                            if (query.searchText.isNotEmpty)
-                              InputChip(
-                                label: Text(query.searchText),
-                                onDeleted: () =>
-                                    ref.read(currentQueryProvider.notifier).state =
-                                        query.copyWith(searchText: ''),
-                              ),
-                            if (query.filters.contains(WordFilter.unviewed))
-                              InputChip(
-                                label: const Text('未閲覧'),
-                                onDeleted: () {
-                                  final newFilters = {...query.filters}
-                                    ..remove(WordFilter.unviewed);
-                                  ref
-                                      .read(currentQueryProvider.notifier)
-                                      .state =
-                                          query.copyWith(filters: newFilters);
-                                },
-                              ),
-                            if (query.filters.contains(WordFilter.wrongOnly))
-                              InputChip(
-                                label: const Text('間違えのみ'),
-                                onDeleted: () {
-                                  final newFilters = {...query.filters}
-                                    ..remove(WordFilter.wrongOnly);
-                                  ref
-                                      .read(currentQueryProvider.notifier)
-                                      .state =
-                                          query.copyWith(filters: newFilters);
-                                },
-                              ),
-                          ],
-                        ),
-                      )
-                    : const SizedBox.shrink(),
-              )
-            : null,
         actions: [
           if (_currentScreen == AppScreen.wordList || _currentScreen == AppScreen.quiz)
             DropdownButtonHideUnderline(
@@ -396,42 +368,12 @@ class _MainScreenState extends ConsumerState<MainScreen> {
                     .toList(),
               ),
             ),
-          if (_currentScreen == AppScreen.wordList) ...[
-            Semantics(
-              label: '検索',
-              button: true,
-              child: IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                  _wordListKey.currentState?.openFilterSheet(context);
-                },
-              ),
+          if (_currentScreen == AppScreen.wordList)
+            OverflowMenu(
+              onOpenSheet: () {
+                _wordListKey.currentState?.openFilterSheet(context);
+              },
             ),
-            Semantics(
-              label: '並び替え',
-              button: true,
-              child: IconButton(
-                icon: const Icon(Icons.sort),
-                onPressed: () {
-                  _wordListKey.currentState?.openFilterSheet(context);
-                },
-              ),
-            ),
-            Semantics(
-              label: 'フィルター',
-              button: true,
-              child: badges.Badge(
-                badgeContent: Text('${query.filters.length}'),
-                showBadge: query.filters.isNotEmpty,
-                child: IconButton(
-                  icon: const Icon(Icons.filter_alt_outlined),
-                  onPressed: () {
-                    _wordListKey.currentState?.openFilterSheet(context);
-                  },
-                ),
-              ),
-            ),
-          ],
           if (_currentScreen != AppScreen.settings)
             IconButton(
               icon: const Icon(Icons.settings_outlined),

--- a/lib/overflow_menu.dart
+++ b/lib/overflow_menu.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'word_list_query.dart';
+
+enum _OverflowAction { search, filter, clear }
+
+/// Popup menu used in the word list AppBar.
+class OverflowMenu extends ConsumerWidget {
+  final VoidCallback onOpenSheet;
+  const OverflowMenu({Key? key, required this.onOpenSheet}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final query = ref.watch(currentQueryProvider);
+    return PopupMenuButton<_OverflowAction>(
+      icon: const Icon(Icons.more_vert),
+      onSelected: (action) {
+        switch (action) {
+          case _OverflowAction.search:
+          case _OverflowAction.filter:
+            onOpenSheet();
+            break;
+          case _OverflowAction.clear:
+            ref.read(currentQueryProvider.notifier).state = query.reset();
+            break;
+        }
+      },
+      itemBuilder: (context) => const [
+        PopupMenuItem(
+          value: _OverflowAction.search,
+          child: Text('検索'),
+        ),
+        PopupMenuItem(
+          value: _OverflowAction.filter,
+          child: Text('フィルタ'),
+        ),
+        PopupMenuItem(
+          value: _OverflowAction.clear,
+          child: Text('条件クリア'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:badges/badges.dart' as badges;
 
 import '../flashcard_model.dart';
 import '../flashcard_repository.dart';
@@ -62,6 +61,57 @@ class WordListTabContentState extends ConsumerState<WordListTabContent> {
 
         return CustomScrollView(
           slivers: [
+            if (query.hasAny)
+              SliverToBoxAdapter(
+                child: SizedBox(
+                  height: 40,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    child: Row(
+                      children: [
+                        if (query.searchText.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(right: 4),
+                            child: InputChip(
+                              label: Text(query.searchText),
+                              onDeleted: () =>
+                                  ref.read(currentQueryProvider.notifier).state =
+                                      query.copyWith(searchText: ''),
+                            ),
+                          ),
+                        if (query.filters.contains(WordFilter.unviewed))
+                          Padding(
+                            padding: const EdgeInsets.only(right: 4),
+                            child: InputChip(
+                              label: const Text('未閲覧'),
+                              onDeleted: () {
+                                final newFilters = {...query.filters}
+                                  ..remove(WordFilter.unviewed);
+                                ref.read(currentQueryProvider.notifier).state =
+                                    query.copyWith(filters: newFilters);
+                              },
+                            ),
+                          ),
+                        if (query.filters.contains(WordFilter.wrongOnly))
+                          Padding(
+                            padding: const EdgeInsets.only(right: 4),
+                            child: InputChip(
+                              label: const Text('間違えのみ'),
+                              onDeleted: () {
+                                final newFilters = {...query.filters}
+                                  ..remove(WordFilter.wrongOnly);
+                                ref.read(currentQueryProvider.notifier).state =
+                                    query.copyWith(filters: newFilters);
+                              },
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
             if (filtered.isEmpty)
               SliverFillRemaining(
                 hasScrollBody: false,

--- a/lib/word_list_query.dart
+++ b/lib/word_list_query.dart
@@ -34,6 +34,12 @@ class WordListQuery {
     this.filters = const {},
   });
 
+  /// True if any search text or filters are set.
+  bool get hasAny => searchText.isNotEmpty || filters.isNotEmpty;
+
+  /// Return the default empty query.
+  WordListQuery reset() => const WordListQuery();
+
   /// Return a copy with updated fields.
   WordListQuery copyWith({
     String? searchText,

--- a/lib/word_query_sheet.dart
+++ b/lib/word_query_sheet.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'word_list_query.dart';
-import 'sort_type_ext.dart';
 
 /// Bottom sheet widget for editing [WordListQuery].
 class WordQuerySheet extends StatefulWidget {
@@ -14,13 +13,11 @@ class WordQuerySheet extends StatefulWidget {
 
 class _WordQuerySheetState extends State<WordQuerySheet> {
   late TextEditingController _controller;
-  late SortType _sort;
   late Set<WordFilter> _filters;
 
   @override
   void initState() {
     super.initState();
-    _sort = widget.initial.sort;
     _filters = {...widget.initial.filters};
     _controller = TextEditingController(text: widget.initial.searchText);
   }
@@ -50,23 +47,6 @@ class _WordQuerySheetState extends State<WordQuerySheet> {
                     labelText: '検索語',
                     prefixIcon: Icon(Icons.search),
                   ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Column(
-                  children: SortType.values
-                      .map(
-                        (m) => RadioListTile<SortType>(
-                          title: Text(m.label),
-                          value: m,
-                          groupValue: _sort,
-                          onChanged: (v) => setState(() {
-                            if (v != null) _sort = v;
-                          }),
-                        ),
-                      )
-                      .toList(),
                 ),
               ),
               Padding(
@@ -113,7 +93,6 @@ class _WordQuerySheetState extends State<WordQuerySheet> {
                         Navigator.of(context).pop(
                           widget.initial.copyWith(
                             searchText: _controller.text,
-                            sort: _sort,
                             filters: _filters,
                           ),
                         );


### PR DESCRIPTION
## Why
- want single-line app bar with sort dropdown and menu
- chips for search/filter should appear in the list
- remove obsolete search/filter icons

## What
- added `OverflowMenu` popup menu
- moved search/filter chips to list header
- added query `hasAny` and `reset`
- simplified query sheet
- updated app bar logic

## How
- `dart format -o none --set-exit-if-changed lib/main_screen.dart lib/overflow_menu.dart lib/tabs_content/word_list_tab_content.dart lib/word_list_query.dart lib/word_query_sheet.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab0da8bd4832a9a4e5454058a2eb3