### PR TITLE
Fix missing import in main screen

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -20,6 +20,7 @@ import 'review_mode_ext.dart';
 import 'word_detail_content.dart'; // 詳細表示用コンテンツウィジェット
 import 'word_detail_controller.dart';
 import 'word_list_query.dart';
+import 'sort_type_ext.dart';
 import 'overflow_menu.dart';
 
 class MainScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
## Summary
- add `sort_type_ext.dart` import so `SortType.label` is resolved

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab737e4e8832a89eb7a0853256959