### PR TITLE
Refactor word sorting logic

### DIFF
--- a/lib/services/word_repository.dart
+++ b/lib/services/word_repository.dart
@@ -4,8 +4,6 @@ import 'package:hive/hive.dart';
 
 import '../models/word.dart';
 
-enum WordSort { kana, importance }
-
 /// Repository for [Word] objects persisted in Hive.
 class WordRepository {
   static const boxName = 'words_box_v1';
@@ -39,17 +37,8 @@ class WordRepository {
 
   Future<void> delete(String id) async => _box.delete(id);
 
-  /// Return all words sorted by [sort].
-  List<Word> list({WordSort sort = WordSort.kana}) {
-    final words = _box.values.toList();
-    switch (sort) {
-      case WordSort.kana:
-        words.sort((a, b) => a.reading.compareTo(b.reading));
-        break;
-      case WordSort.importance:
-        words.sort((a, b) => b.importance.compareTo(a.importance));
-        break;
-    }
-    return words;
+  /// Return all words in the box.
+  List<Word> list() {
+    return _box.values.toList();
   }
 }

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -39,7 +39,7 @@ void main() {
     expect(fetched?.term, 'a');
   });
 
-  test('sorts by kana and importance', () async {
+  test('lists all words after insertion', () async {
     await repo.add(Word(
       id: '1',
       term: 'a',
@@ -63,10 +63,7 @@ void main() {
       importance: 1,
     ));
 
-    final kana = repo.list(sort: WordSort.kana);
-    expect(kana.first.id, '2');
-
-    final imp = repo.list(sort: WordSort.importance);
-    expect(imp.first.id, '1');
+    final words = repo.list();
+    expect(words.length, 2);
   });
 }


### PR DESCRIPTION
## Why
The word list screen had two separate sorting implementations. WordRepository held its own `WordSort` enum while the UI relied on `SortType`. This duplication made maintenance confusing.

## What
- Removed the obsolete `WordSort` enum and related logic from `WordRepository`
- Updated tests to reflect the simplified repository API

## How
- WordRepository `list()` simply returns all stored words
- Adjusted `word_repository_test.dart` to verify listing after insertion

Closes #61

------
https://chatgpt.com/codex/tasks/task_e_685ac2c47434832a9bdb9f36cd2b455d