### PR TITLE
Remove redundant sort menu

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -20,7 +20,6 @@ import 'review_mode_ext.dart';
 import 'word_detail_content.dart'; // 詳細表示用コンテンツウィジェット
 import 'word_detail_controller.dart';
 import 'word_list_query.dart';
-import 'sort_type_ext.dart';
 import 'overflow_menu.dart';
 
 class MainScreen extends ConsumerStatefulWidget {
@@ -279,38 +278,17 @@ class _MainScreenState extends ConsumerState<MainScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: _currentScreen == AppScreen.wordList
-            ? PopupMenuButton<SortType>(
-                initialValue: query.sort,
-                onSelected: (v) {
-                  ref.read(currentQueryProvider.notifier).state =
-                      query.copyWith(sort: v);
-                },
-                itemBuilder: (context) => SortType.values
-                    .map((m) => PopupMenuItem(
-                          value: m,
-                          child: Text(m.label),
-                        ))
-                    .toList(),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(query.sort.label),
-                    const Icon(Icons.arrow_drop_down),
-                  ],
-                ),
-              )
-            : AnimatedBuilder(
-                animation: _detailController,
-                builder: (context, _) {
-                  final baseTitle = _getAppBarTitle();
-                  if (_currentScreen == AppScreen.wordList && words != null) {
-                    return Text(
-                        '$baseTitle (${filtered.length} / ${words.length} 件)');
-                  }
-                  return Text(baseTitle);
-                },
-              ),
+        title: AnimatedBuilder(
+          animation: _detailController,
+          builder: (context, _) {
+            final baseTitle = _getAppBarTitle();
+            if (_currentScreen == AppScreen.wordList && words != null) {
+              return Text(
+                  '$baseTitle (${filtered.length} / ${words.length} 件)');
+            }
+            return Text(baseTitle);
+          },
+        ),
         leadingWidth: _currentScreen == AppScreen.wordDetail ? 96 : null,
         leading: _currentScreen == AppScreen.wordDetail
             ? AnimatedBuilder(


### PR DESCRIPTION
## Summary
- remove SortType dropdown from word list
- show plain AnimatedBuilder title instead

## Testing
- `dart format lib/main_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685b22b7c2c4832a8528072d53c1b588