### PR TITLE
feat(wordbook): add WordbookScreen MVP

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'flashcard_model.dart';
+import 'word_detail_content.dart';
+
+class WordbookScreen extends StatefulWidget {
+  final List<Flashcard> flashcards;
+  const WordbookScreen({Key? key, required this.flashcards}) : super(key: key);
+
+  @override
+  State<WordbookScreen> createState() => _WordbookScreenState();
+}
+
+class _WordbookScreenState extends State<WordbookScreen> {
+  static const _bookmarkKey = 'bookmark_pageIndex';
+  late PageController _pageController;
+  int _currentIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+    _loadBookmark();
+  }
+
+  Future<void> _loadBookmark() async {
+    final prefs = await SharedPreferences.getInstance();
+    final index = prefs.getInt(_bookmarkKey) ?? 0;
+    if (!mounted) return;
+    _pageController.jumpToPage(index);
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  Future<void> _saveBookmark(int index) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_bookmarkKey, index);
+  }
+
+  Future<void> _openSearch() async {
+    final result = await showModalBottomSheet<int>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => _SearchSheet(
+        flashcards: widget.flashcards,
+        currentIndex: _currentIndex,
+      ),
+    );
+    if (!mounted) return;
+    if (result != null) {
+      _pageController.jumpToPage(result);
+      setState(() {
+        _currentIndex = result;
+      });
+      _saveBookmark(result);
+    }
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        titleSpacing: 0,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('単語帳'),
+            Text(
+              '現在 ${_currentIndex + 1} / 全 ${widget.flashcards.length}',
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+          ],
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: _openSearch,
+          ),
+        ],
+      ),
+      body: PageView.builder(
+        controller: _pageController,
+        itemCount: widget.flashcards.length,
+        onPageChanged: (index) {
+          setState(() {
+            _currentIndex = index;
+          });
+          _saveBookmark(index);
+        },
+        itemBuilder: (context, index) {
+          return WordDetailContent(
+            flashcards: [widget.flashcards[index]],
+            initialIndex: 0,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SearchSheet extends StatefulWidget {
+  final List<Flashcard> flashcards;
+  final int currentIndex;
+  const _SearchSheet({required this.flashcards, required this.currentIndex});
+
+  @override
+  State<_SearchSheet> createState() => _SearchSheetState();
+}
+
+class _SearchSheetState extends State<_SearchSheet> {
+  String _query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final results = widget.flashcards
+        .where((c) => c.term.contains(_query) || c.reading.contains(_query))
+        .toList();
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: TextField(
+                autofocus: true,
+                decoration: const InputDecoration(
+                  labelText: '検索',
+                  prefixIcon: Icon(Icons.search),
+                ),
+                onChanged: (v) => setState(() => _query = v),
+              ),
+            ),
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: results.length,
+                itemBuilder: (context, i) {
+                  final card = results[i];
+                  final index = widget.flashcards.indexOf(card);
+                  return ListTile(
+                    title: Text(card.term),
+                    onTap: () => Navigator.of(context).pop(index),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tango/flashcard_model.dart';
+import 'package:tango/wordbook_screen.dart';
+
+Flashcard _card(String id, String term) => Flashcard(
+      id: id,
+      term: term,
+      reading: term,
+      description: 'd',
+      categoryLarge: 'A',
+      categoryMedium: 'B',
+      categorySmall: 'C',
+      categoryItem: 'D',
+      importance: 1,
+      lastReviewed: null,
+      nextDue: null,
+      wrongCount: 0,
+      correctCount: 0,
+    );
+
+void main() {
+  final cards = [_card('1', 'a'), _card('2', 'b')];
+
+  testWidgets('restores bookmark page', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 1});
+    await tester.pumpWidget(MaterialApp(home: WordbookScreen(flashcards: cards)));
+    await tester.pumpAndSettle();
+    expect(find.text('現在 2 / 全 2'), findsOneWidget);
+  });
+
+  testWidgets('saves bookmark on page change', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    await tester.pumpWidget(MaterialApp(home: WordbookScreen(flashcards: cards)));
+    await tester.drag(find.byType(PageView), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getInt('bookmark_pageIndex'), 1);
+  });
+}


### PR DESCRIPTION
## Why
- implement roadmap item 1 in README

## What
- added `WordbookScreen` that keeps page bookmarks and search
- widget tests ensure bookmark restore/save behavior

## How
- new stateful screen with `PageView` and `SharedPreferences`
- bottom sheet search jumps to selected page

- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] `dart format`


------
https://chatgpt.com/codex/tasks/task_e_685d57874900832a97d59645f9e5e21c