### PR TITLE
Refactor WordbookScreen prefs injection

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -6,7 +6,12 @@ import 'word_detail_content.dart';
 
 class WordbookScreen extends StatefulWidget {
   final List<Flashcard> flashcards;
-  const WordbookScreen({Key? key, required this.flashcards}) : super(key: key);
+  final Future<SharedPreferences> Function() prefsProvider;
+  const WordbookScreen({
+    Key? key,
+    required this.flashcards,
+    this.prefsProvider = SharedPreferences.getInstance,
+  }) : super(key: key);
 
   @override
   State<WordbookScreen> createState() => _WordbookScreenState();
@@ -25,7 +30,7 @@ class _WordbookScreenState extends State<WordbookScreen> {
   }
 
   Future<void> _loadBookmark() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await widget.prefsProvider();
     final index = prefs.getInt(_bookmarkKey) ?? 0;
     if (!mounted) return;
     _pageController.jumpToPage(index);
@@ -35,7 +40,7 @@ class _WordbookScreenState extends State<WordbookScreen> {
   }
 
   Future<void> _saveBookmark(int index) async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await widget.prefsProvider();
     await prefs.setInt(_bookmarkKey, index);
   }
 

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -25,23 +25,37 @@ void main() {
 
   testWidgets('restores bookmark page', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 1});
-    await tester.pumpWidget(MaterialApp(home: WordbookScreen(flashcards: cards)));
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+        home: WordbookScreen(
+      flashcards: cards,
+      prefsProvider: () async => prefs,
+    )));
     await tester.pumpAndSettle();
     expect(find.text('現在 2 / 全 2'), findsOneWidget);
   });
 
   testWidgets('saves bookmark on page change', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
-    await tester.pumpWidget(MaterialApp(home: WordbookScreen(flashcards: cards)));
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+        home: WordbookScreen(
+      flashcards: cards,
+      prefsProvider: () async => prefs,
+    )));
     await tester.drag(find.byType(PageView), const Offset(-400, 0));
     await tester.pumpAndSettle();
-    final prefs = await SharedPreferences.getInstance();
     expect(prefs.getInt('bookmark_pageIndex'), 1);
   });
 
   testWidgets('search selects page and saves bookmark', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
-    await tester.pumpWidget(MaterialApp(home: WordbookScreen(flashcards: cards)));
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+        home: WordbookScreen(
+      flashcards: cards,
+      prefsProvider: () async => prefs,
+    )));
 
     // Open search bottom sheet
     await tester.tap(find.byIcon(Icons.search));
@@ -57,7 +71,6 @@ void main() {
     expect(find.text('現在 2 / 全 2'), findsOneWidget);
 
     // Bookmark saved
-    final prefs = await SharedPreferences.getInstance();
     expect(prefs.getInt('bookmark_pageIndex'), 1);
   });
 }


### PR DESCRIPTION
## Summary
- allow dependency injection of `SharedPreferences` in `WordbookScreen`
- update widget tests to inject mock `SharedPreferences`

## Testing
- `flutter analyze` *(fails: Unable to 'pub upgrade' flutter tool)*
- `flutter test` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_685dd62d3248832a88f47cd1f856b2ef