### PR TITLE
Implement StudySessionController with UI

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -2,3 +2,5 @@ const String favoritesBoxName = 'favorites_box_v2';
 const String historyBoxName = 'history_box_v2';
 const String quizStatsBoxName = 'quiz_stats_box_v1';
 const String flashcardStateBoxName = 'flashcard_state_box';
+const String sessionLogBoxName = 'session_log_box_v1';
+const String reviewQueueBoxName = 'review_queue_box_v1';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,8 @@ import 'history_entry_model.dart';
 import 'models/word.dart';
 import 'models/learning_stat.dart';
 import 'models/quiz_stat.dart';
+import 'models/session_log.dart';
+import 'models/review_queue.dart';
 import 'constants.dart';
 import 'services/word_repository.dart';
 import 'services/learning_repository.dart';
@@ -65,6 +67,12 @@ Future<void> main() async {
   if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
     Hive.registerAdapter(QuizStatAdapter());
   }
+  if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+    Hive.registerAdapter(SessionLogAdapter());
+  }
+  if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+    Hive.registerAdapter(ReviewQueueAdapter());
+  }
 
   final key = await _getEncryptionKey();
   final cipher = HiveAesCipher(key);
@@ -75,6 +83,8 @@ Future<void> main() async {
   await _openBoxWithMigration<Map>(flashcardStateBoxName, cipher);
   await _openBoxWithMigration<Word>(WordRepository.boxName, cipher);
   await _openBoxWithMigration<LearningStat>(LearningRepository.boxName, cipher);
+  await _openBoxWithMigration<SessionLog>(sessionLogBoxName, cipher);
+  await _openBoxWithMigration<ReviewQueue>(reviewQueueBoxName, cipher);
 
   final themeProvider = ThemeProvider();
   await themeProvider.loadAppPreferences();

--- a/lib/models/review_queue.dart
+++ b/lib/models/review_queue.dart
@@ -1,0 +1,11 @@
+import 'package:hive/hive.dart';
+
+part 'review_queue.g.dart';
+
+@HiveType(typeId: 6)
+class ReviewQueue extends HiveObject {
+  @HiveField(0)
+  List<String> wordIds;
+
+  ReviewQueue({List<String>? wordIds}) : wordIds = wordIds ?? [];
+}

--- a/lib/models/review_queue.g.dart
+++ b/lib/models/review_queue.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'review_queue.dart';
+
+class ReviewQueueAdapter extends TypeAdapter<ReviewQueue> {
+  @override
+  final int typeId = 6;
+
+  @override
+  ReviewQueue read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ReviewQueue(
+      wordIds: (fields[0] as List).cast<String>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ReviewQueue obj) {
+    writer
+      ..writeByte(1)
+      ..writeByte(0)
+      ..write(obj.wordIds);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ReviewQueueAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/models/session_log.dart
+++ b/lib/models/session_log.dart
@@ -1,0 +1,24 @@
+import 'package:hive/hive.dart';
+
+part 'session_log.g.dart';
+
+@HiveType(typeId: 5)
+class SessionLog extends HiveObject {
+  @HiveField(0)
+  final DateTime startTime;
+  @HiveField(1)
+  final DateTime endTime;
+  @HiveField(2)
+  final int wordCount;
+  @HiveField(3)
+  final int correctCount;
+
+  SessionLog({
+    required this.startTime,
+    required this.endTime,
+    required this.wordCount,
+    required this.correctCount,
+  });
+
+  int get durationSeconds => endTime.difference(startTime).inSeconds;
+}

--- a/lib/models/session_log.g.dart
+++ b/lib/models/session_log.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'session_log.dart';
+
+class SessionLogAdapter extends TypeAdapter<SessionLog> {
+  @override
+  final int typeId = 5;
+
+  @override
+  SessionLog read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return SessionLog(
+      startTime: fields[0] as DateTime,
+      endTime: fields[1] as DateTime,
+      wordCount: fields[2] as int,
+      correctCount: fields[3] as int,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, SessionLog obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.startTime)
+      ..writeByte(1)
+      ..write(obj.endTime)
+      ..writeByte(2)
+      ..write(obj.wordCount)
+      ..writeByte(3)
+      ..write(obj.correctCount);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionLogAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/services/review_queue_service.dart
+++ b/lib/services/review_queue_service.dart
@@ -1,0 +1,26 @@
+import 'package:hive/hive.dart';
+
+import '../models/review_queue.dart';
+import '../constants.dart';
+
+class ReviewQueueService {
+  final Box<ReviewQueue> _box;
+
+  ReviewQueueService([Box<ReviewQueue>? box])
+      : _box = box ?? Hive.box<ReviewQueue>(reviewQueueBoxName);
+
+  ReviewQueue get _queue => _box.get('queue') ?? ReviewQueue();
+
+  Future<void> pushAll(List<String> ids) async {
+    final q = _queue;
+    for (final id in ids) {
+      if (!q.wordIds.contains(id)) {
+        q.wordIds.add(id);
+        if (q.wordIds.length > 200) {
+          q.wordIds.removeAt(0);
+        }
+      }
+    }
+    await _box.put('queue', q);
+  }
+}

--- a/lib/study_session_controller.dart
+++ b/lib/study_session_controller.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import 'flashcard_model.dart';
+import 'models/session_log.dart';
+import 'services/learning_repository.dart';
+import 'services/review_queue_service.dart';
+import 'constants.dart';
+
+class StudySessionState {
+  final List<Flashcard> words;
+  final int targetWords;
+  final int targetMinutes;
+  final int currentIndex;
+  final bool inQuiz;
+  final bool finished;
+  final DateTime? startTime;
+  final List<bool> results;
+
+  StudySessionState({
+    required this.words,
+    required this.targetWords,
+    required this.targetMinutes,
+    required this.currentIndex,
+    required this.inQuiz,
+    required this.finished,
+    required this.startTime,
+    required this.results,
+  });
+
+  factory StudySessionState.initial() => StudySessionState(
+        words: const [],
+        targetWords: 0,
+        targetMinutes: 0,
+        currentIndex: 0,
+        inQuiz: false,
+        finished: false,
+        startTime: null,
+        results: const [],
+      );
+
+  StudySessionState copyWith({
+    List<Flashcard>? words,
+    int? targetWords,
+    int? targetMinutes,
+    int? currentIndex,
+    bool? inQuiz,
+    bool? finished,
+    DateTime? startTime,
+    List<bool>? results,
+  }) {
+    return StudySessionState(
+      words: words ?? this.words,
+      targetWords: targetWords ?? this.targetWords,
+      targetMinutes: targetMinutes ?? this.targetMinutes,
+      currentIndex: currentIndex ?? this.currentIndex,
+      inQuiz: inQuiz ?? this.inQuiz,
+      finished: finished ?? this.finished,
+      startTime: startTime ?? this.startTime,
+      results: results ?? this.results,
+    );
+  }
+}
+
+class StudySessionController extends StateNotifier<StudySessionState> {
+  LearningRepository? _learningRepo;
+  final Box<SessionLog> _logBox;
+  final ReviewQueueService _queueService;
+  Timer? _timer;
+
+  StudySessionController(this._logBox, this._queueService)
+      : super(StudySessionState.initial());
+
+  Future<LearningRepository> _repo() async {
+    _learningRepo ??= await LearningRepository.open();
+    return _learningRepo!;
+  }
+
+  Future<void> start({
+    required List<Flashcard> words,
+    required int targetWords,
+    required int targetMinutes,
+  }) async {
+    _timer?.cancel();
+    final now = DateTime.now();
+    state = StudySessionState(
+      words: words.take(targetWords).toList(),
+      targetWords: targetWords,
+      targetMinutes: targetMinutes,
+      currentIndex: 0,
+      inQuiz: false,
+      finished: false,
+      startTime: now,
+      results: [],
+    );
+    if (targetMinutes > 0) {
+      _timer = Timer(Duration(minutes: targetMinutes), finish);
+    }
+  }
+
+  Flashcard? get currentWord {
+    if (state.currentIndex >= state.words.length) return null;
+    return state.words[state.currentIndex];
+  }
+
+  Future<void> answer(bool correct) async {
+    final word = currentWord;
+    if (word == null) return;
+    final repo = await _repo();
+    if (!correct) {
+      await repo.incrementWrong(word.id);
+    }
+    await repo.markReviewed(word.id);
+    final list = [...state.results, correct];
+    state = state.copyWith(results: list);
+  }
+
+  Future<void> next() async {
+    if (state.finished) return;
+    if (!state.inQuiz) {
+      state = state.copyWith(inQuiz: true);
+    } else {
+      final nextIndex = state.currentIndex + 1;
+      if (nextIndex >= state.words.length) {
+        await finish();
+      } else {
+        state = state.copyWith(currentIndex: nextIndex, inQuiz: false);
+      }
+    }
+  }
+
+  Future<void> finish() async {
+    if (state.finished) return;
+    _timer?.cancel();
+    final end = DateTime.now();
+    final log = SessionLog(
+      startTime: state.startTime ?? end,
+      endTime: end,
+      wordCount: state.words.length,
+      correctCount: state.results.where((e) => e).length,
+    );
+    await _logBox.add(log);
+    final wrongIds = <String>[];
+    for (int i = 0; i < state.words.length && i < state.results.length; i++) {
+      if (!state.results[i]) wrongIds.add(state.words[i].id);
+    }
+    await _queueService.pushAll(wrongIds);
+    state = state.copyWith(finished: true);
+  }
+}
+
+final studySessionControllerProvider =
+    StateNotifierProvider<StudySessionController, StudySessionState>((ref) {
+  final box = Hive.box<SessionLog>(sessionLogBoxName);
+  final queue = ReviewQueueService();
+  return StudySessionController(box, queue);
+});

--- a/lib/study_start_sheet.dart
+++ b/lib/study_start_sheet.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'review_service.dart';
+import 'study_session_controller.dart';
+import 'flashcard_model.dart';
+import 'flashcard_repository.dart';
+
+class StudyStartSheet extends ConsumerStatefulWidget {
+  const StudyStartSheet({super.key});
+
+  @override
+  ConsumerState<StudyStartSheet> createState() => _StudyStartSheetState();
+}
+
+class _StudyStartSheetState extends ConsumerState<StudyStartSheet> {
+  int _wordCount = 10;
+  int _timerIndex = 0;
+  final List<int> _timerOptions = [0, 15, 25, 30];
+
+  Future<void> _start() async {
+    final service = ReviewService();
+    final all = await service.fetchForMode(ReviewMode.random);
+    final words = all.take(_wordCount).toList();
+    if (!mounted || words.isEmpty) return;
+    Navigator.of(context).pop();
+    ref.read(studySessionControllerProvider.notifier).start(
+          words: words,
+          targetWords: _wordCount,
+          targetMinutes: _timerOptions[_timerIndex],
+        );
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const StudySessionScreen()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('語数: $_wordCount'),
+            Slider(
+              value: _wordCount.toDouble(),
+              min: 10,
+              max: 100,
+              divisions: 9,
+              label: _wordCount.toString(),
+              onChanged: (v) => setState(() => _wordCount = v.round()),
+            ),
+            const SizedBox(height: 8),
+            const Text('タイマー'),
+            ToggleButtons(
+              isSelected: List.generate(
+                _timerOptions.length,
+                (i) => _timerIndex == i,
+              ),
+              onPressed: (i) => setState(() => _timerIndex = i),
+              children: const [
+                Padding(padding: EdgeInsets.all(8), child: Text('OFF')),
+                Padding(padding: EdgeInsets.all(8), child: Text('15m')),
+                Padding(padding: EdgeInsets.all(8), child: Text('25m')),
+                Padding(padding: EdgeInsets.all(8), child: Text('30m')),
+              ],
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _start,
+                child: const Text('開始'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> showStudyStartSheet(BuildContext context) async {
+  await showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => const StudyStartSheet(),
+  );
+}
+
+class StudySessionScreen extends ConsumerStatefulWidget {
+  const StudySessionScreen({super.key});
+
+  @override
+  ConsumerState<StudySessionScreen> createState() => _StudySessionScreenState();
+}
+
+class _StudySessionScreenState extends ConsumerState<StudySessionScreen> {
+  bool _showAnswer = false;
+  List<Flashcard> _choices = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadChoices();
+  }
+
+  void _loadChoices() async {
+    final state = ref.read(studySessionControllerProvider);
+    if (state.words.isEmpty) return;
+    final all = await FlashcardRepository.loadAll();
+    final word = state.words[state.currentIndex];
+    _choices = List<Flashcard>.from(all)
+      ..removeWhere((c) => c.id == word.id);
+    _choices.shuffle();
+    _choices = (_choices.take(3).toList()..add(word))..shuffle();
+    if (mounted) setState(() {});
+  }
+
+  void _next() async {
+    setState(() => _showAnswer = false);
+    await ref.read(studySessionControllerProvider.notifier).next();
+    _loadChoices();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(studySessionControllerProvider);
+    if (state.finished) {
+      final acc = state.results.isEmpty
+          ? 0
+          : (state.results.where((e) => e).length / state.results.length * 100)
+              .round();
+      return Scaffold(
+        appBar: AppBar(title: const Text('学習結果')),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('学習時間: ${state.startTime != null ? DateTime.now().difference(state.startTime!).inSeconds : 0}秒'),
+              Text('正答率: $acc%'),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('閉じる'),
+              )
+            ],
+          ),
+        ),
+      );
+    }
+    final word = state.words[state.currentIndex];
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${state.currentIndex + 1} / ${state.words.length}'),
+        actions: [
+          TextButton(
+            onPressed: ref.read(studySessionControllerProvider.notifier).finish,
+            child: const Text('終了'),
+          )
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Expanded(
+              child: WordDetailContent(
+                flashcards: [word],
+                initialIndex: 0,
+              ),
+            ),
+            if (!state.inQuiz)
+              ElevatedButton(
+                onPressed: _next,
+                child: const Text('次へ'),
+              )
+            else if (!_showAnswer)
+              Column(
+                children: _choices
+                    .map(
+                      (c) => Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 4),
+                        child: SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            onPressed: () {
+                              setState(() => _showAnswer = true);
+                              ref
+                                  .read(studySessionControllerProvider.notifier)
+                                  .answer(c.term == word.term);
+                            },
+                            child: Text(c.term),
+                          ),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              )
+            else
+              Column(
+                children: [
+                  Text(
+                    state.results.last ? '正解!' : '不正解',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: _next,
+                    child: const Text('次へ'),
+                  )
+                ],
+              )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:tango/constants.dart';
+import 'package:tango/flashcard_model.dart';
+import 'package:tango/models/learning_stat.dart';
+import 'package:tango/models/session_log.dart';
+import 'package:tango/services/review_queue_service.dart';
+import 'package:tango/study_session_controller.dart';
+import 'package:tango/study_start_sheet.dart';
+
+void main() {
+  setUpAll(() async {
+    Hive.init('./testdb');
+    Hive.registerAdapter(SessionLogAdapter());
+    Hive.registerAdapter(LearningStatAdapter());
+    Hive.registerAdapter(ReviewQueueAdapter());
+    await Hive.openBox<SessionLog>(sessionLogBoxName);
+    await Hive.openBox<LearningStat>(LearningRepository.boxName);
+    await Hive.openBox(reviewQueueBoxName);
+  });
+
+  tearDownAll(() async {
+    await Hive.deleteBoxFromDisk(sessionLogBoxName);
+    await Hive.deleteBoxFromDisk(LearningRepository.boxName);
+    await Hive.deleteBoxFromDisk(reviewQueueBoxName);
+  });
+
+  Flashcard _card(String id) => Flashcard(
+        id: id,
+        term: id,
+        reading: id,
+        description: 'd',
+        categoryLarge: 'A',
+        categoryMedium: 'B',
+        categorySmall: 'C',
+        categoryItem: 'D',
+        importance: 1,
+      );
+
+  testWidgets('flow one word', (tester) async {
+    final words = [_card('1')];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          studySessionControllerProvider.overrideWith((ref) {
+            final logBox = Hive.box<SessionLog>(sessionLogBoxName);
+            final queueBox = Hive.box(reviewQueueBoxName);
+            return StudySessionController(logBox, ReviewQueueService(queueBox));
+          })
+        ],
+        child: const MaterialApp(home: Scaffold()),
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () => showStudyStartSheet(context),
+                child: const Text('start'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('start'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('開始'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(StudySessionScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add constants for session log and review queue
- implement `SessionLog` & `ReviewQueue` models
- create `ReviewQueueService`
- implement `StudySessionController` with Riverpod
- add start sheet and session screen widgets
- register new Hive adapters
- add basic controller and widget tests

## Testing
- `dart format` *(fails: `command not found`)*
- `flutter analyze` *(fails: `command not found`)*
- `flutter test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685de2ef3788832a8605b9b7982eadf8