### PR TITLE
Add HistoryScreen with session analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ ReviewQueue（弱点語 FIFO 200）を Hive Box として実装し、クイズ�
 
 * キューが空ならボタンを無効化* クイズ終了で正答語はキューから削除* 単体テストで ReviewQueue ロジック検証
 
-4
+4 ✅
 
 HistoryScreen
 

--- a/lib/history_screen.dart
+++ b/lib/history_screen.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:intl/intl.dart';
+
+import 'services/aggregator.dart';
+
+enum DateRange { week7, month30, month90, all }
+
+final historyFilterProvider =
+    StateProvider<DateRange>((ref) => DateRange.week7);
+
+final dailyStudyProvider = FutureProvider<Map<DateTime, Duration>>((ref) {
+  final range = ref.watch(historyFilterProvider);
+  final agg = SessionAggregator();
+  final now = DateTime.now();
+  DateTime from;
+  switch (range) {
+    case DateRange.week7:
+      from = now.subtract(const Duration(days: 6));
+      break;
+    case DateRange.month30:
+      from = now.subtract(const Duration(days: 29));
+      break;
+    case DateRange.month90:
+      from = now.subtract(const Duration(days: 89));
+      break;
+    case DateRange.all:
+      from = DateTime(2000);
+      break;
+  }
+  return agg.dailyStudyTime(from: from, to: now);
+});
+
+class HistoryScreen extends ConsumerWidget {
+  const HistoryScreen({super.key});
+
+  Color _colorForMinutes(int minutes, BuildContext context) {
+    if (minutes == 0) return Colors.grey.shade200;
+    if (minutes <= 10) return Colors.blue.shade100;
+    if (minutes <= 30) return Colors.blue.shade300;
+    return Colors.blue.shade700;
+  }
+
+  Widget _buildHeatmap(BuildContext context, Map<DateTime, Duration> data) {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, 1);
+    final end = DateTime(now.year, now.month + 1, 1);
+    final days = <DateTime>[];
+    for (var d = start; d.isBefore(end); d = d.add(const Duration(days: 1))) {
+      days.add(d);
+    }
+    final firstWeekday = start.weekday % 7;
+    final cells = <Widget>[];
+    for (int i = 0; i < firstWeekday; i++) {
+      cells.add(const SizedBox.shrink());
+    }
+    for (final day in days) {
+      final mins = data[day]?.inMinutes ?? 0;
+      cells.add(Container(
+        alignment: Alignment.center,
+        margin: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          color: _colorForMinutes(mins, context),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text('${day.day}',
+            style: Theme.of(context)
+                .textTheme
+                .labelSmall
+                ?.copyWith(fontSize: 10)),
+      ));
+    }
+    return GridView.count(
+      crossAxisCount: 7,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      children: cells,
+    );
+  }
+
+  LineChartData _chartData(
+      BuildContext context, List<MapEntry<DateTime, Duration>> entries) {
+    final spots = entries
+        .map((e) => FlSpot(
+            e.key.millisecondsSinceEpoch.toDouble(),
+            e.value.inMinutes.toDouble()))
+        .toList();
+    return LineChartData(
+      lineBarsData: [
+        LineChartBarData(
+          spots: spots,
+          isCurved: true,
+          dotData: FlDotData(show: false),
+          belowBarData: BarAreaData(show: true, opacity: .15),
+        )
+      ],
+      titlesData: FlTitlesData(
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: const Duration(days: 1).inMilliseconds.toDouble(),
+            getTitlesWidget: (value, meta) {
+              final date =
+                  DateTime.fromMillisecondsSinceEpoch(value.toInt());
+              return Text(
+                DateFormat('M/d').format(date),
+                style:
+                    Theme.of(context).textTheme.labelSmall?.copyWith(fontSize: 10),
+              );
+            },
+          ),
+        ),
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(showTitles: true),
+        ),
+        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      ),
+      gridData: FlGridData(show: false),
+      borderData: FlBorderData(show: false),
+    );
+  }
+
+  Widget _summary(Map<DateTime, Duration> data, int streak) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final weekStart = today.subtract(const Duration(days: 6));
+    final todayMin = data[today]?.inMinutes ?? 0;
+    final weekMin = data.entries
+        .where((e) => !e.key.isBefore(weekStart))
+        .fold<int>(0, (p, e) => p + e.value.inMinutes);
+    Widget card(String label, String value) {
+      return Card(
+        child: SizedBox(
+          width: 120,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(label),
+                const SizedBox(height: 4),
+                Text(value,
+                    style: const TextStyle(
+                        fontSize: 18, fontWeight: FontWeight.bold)),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return SizedBox(
+      height: 100,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        children: [
+          card('今日', '$todayMin分'),
+          card('今週', '$weekMin分'),
+          card('連続', '$streak日'),
+        ],
+      ),
+    );
+  }
+
+  Widget _emptyView(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(Icons.insights_outlined,
+            size: 48, color: Theme.of(context).colorScheme.outline),
+        const SizedBox(height: 8),
+        const Text('データがありません'),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final range = ref.watch(historyFilterProvider);
+    final asyncDaily = ref.watch(dailyStudyProvider);
+    final aggregator = SessionAggregator();
+    return asyncDaily.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('$e')),
+      data: (data) {
+        if (data.isEmpty) {
+          return Center(child: _emptyView(context));
+        }
+        final entries = data.entries.toList()
+          ..sort((a, b) => a.key.compareTo(b.key));
+        final streak = aggregator.currentStreak();
+        final now = DateTime.now();
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            _summary(data, streak),
+            const SizedBox(height: 16),
+            SegmentedButton<DateRange>(
+              segments: const [
+                ButtonSegment(value: DateRange.week7, label: Text('7日')),
+                ButtonSegment(value: DateRange.month30, label: Text('30日')),
+                ButtonSegment(value: DateRange.month90, label: Text('90日')),
+                ButtonSegment(value: DateRange.all, label: Text('ALL')),
+              ],
+              selected: {range},
+              onSelectionChanged: (vals) {
+                ref.read(historyFilterProvider.notifier).state = vals.first;
+              },
+            ),
+            const SizedBox(height: 8),
+            SizedBox(height: 200, child: LineChart(_chartData(context, entries))),
+            const SizedBox(height: 24),
+            FutureBuilder<Map<DateTime, Duration>>(
+              future: aggregator.dailyStudyTime(
+                from: DateTime(now.year, now.month, 1),
+                to: DateTime(now.year, now.month + 1, 1),
+              ),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const SizedBox(height: 200);
+                }
+                return _buildHeatmap(context, snapshot.data!);
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -9,7 +9,7 @@ import 'flashcard_model.dart'; // Flashcard モデル
 import 'tabs_content/home_tab_content.dart';
 import 'tabs_content/word_list_tab_content.dart';
 import 'tabs_content/favorites_tab_content.dart';
-import 'tabs_content/history_tab_content.dart';
+import 'history_screen.dart';
 import 'tabs_content/quiz_tab_content.dart';
 import 'tabs_content/settings_tab_content.dart'; // 設定画面コンテンツ
 import 'learning_history_detail_screen.dart';
@@ -127,10 +127,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
           navigateTo: _navigateTo,
         );
       case AppScreen.history:
-        return HistoryTabContent(
-          key: const ValueKey("HistoryTabContent"),
-          navigateTo: _navigateTo,
-        );
+        return const HistoryScreen(key: ValueKey('HistoryScreen'));
       case AppScreen.quiz:
         return QuizTabContent(
           // ★ navigateTo を渡す

--- a/lib/services/aggregator.dart
+++ b/lib/services/aggregator.dart
@@ -1,0 +1,48 @@
+import 'package:hive/hive.dart';
+
+import '../models/session_log.dart';
+import '../constants.dart';
+
+class SessionAggregator {
+  final Box<SessionLog> _box;
+
+  SessionAggregator([Box<SessionLog>? box])
+      : _box = box ?? Hive.box<SessionLog>(sessionLogBoxName);
+
+  Future<Map<DateTime, Duration>> dailyStudyTime({
+    DateTime? from,
+    DateTime? to,
+  }) async {
+    final logs = _box.values.toList();
+    if (logs.isEmpty) return {};
+    final start = from ??
+        logs.map((e) => e.startTime).reduce((a, b) => a.isBefore(b) ? a : b);
+    final end = to ?? DateTime.now();
+    final Map<DateTime, Duration> result = {};
+    for (final log in logs) {
+      if (log.startTime.isBefore(start) || log.startTime.isAfter(end)) continue;
+      final date = DateTime(log.startTime.year, log.startTime.month, log.startTime.day);
+      final dur = log.endTime.difference(log.startTime);
+      result[date] = (result[date] ?? Duration.zero) + dur;
+    }
+    return result;
+  }
+
+  int currentStreak() {
+    final dates = _box.values.map((e) {
+      return DateTime(e.startTime.year, e.startTime.month, e.startTime.day);
+    }).toSet();
+    int streak = 0;
+    DateTime day = DateTime.now();
+    while (true) {
+      final d = DateTime(day.year, day.month, day.day);
+      if (dates.contains(d)) {
+        streak += 1;
+        day = day.subtract(const Duration(days: 1));
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+}

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:tango/history_screen.dart';
+import 'package:tango/models/session_log.dart';
+import 'package:tango/constants.dart';
+
+void main() {
+  setUp(() async {
+    Hive.init('./testdb_empty');
+    Hive.registerAdapter(SessionLogAdapter());
+    await Hive.openBox<SessionLog>(sessionLogBoxName);
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk(sessionLogBoxName);
+    final dir = Directory('./testdb_empty');
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  testWidgets('shows empty message when no data', (tester) async {
+    await tester.pumpWidget(const ProviderScope(
+      child: MaterialApp(home: HistoryScreen()),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('データがありません'), findsOneWidget);
+  });
+}

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tango/models/session_log.dart';
+import 'package:tango/services/aggregator.dart';
+import 'package:tango/constants.dart';
+
+void main() {
+  late Directory dir;
+  late Box<SessionLog> box;
+  late SessionAggregator aggregator;
+
+  SessionLog _log(DateTime start, int minutes) => SessionLog(
+        startTime: start,
+        endTime: start.add(Duration(minutes: minutes)),
+        wordCount: 0,
+        correctCount: 0,
+      );
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(SessionLogAdapter());
+    box = await Hive.openBox<SessionLog>(sessionLogBoxName);
+    aggregator = SessionAggregator(box);
+  });
+
+  tearDown(() async {
+    await box.close();
+    await Hive.deleteBoxFromDisk(sessionLogBoxName);
+    await dir.delete(recursive: true);
+  });
+
+  test('aggregates and streak', () async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    await box.add(_log(today.add(const Duration(hours: 1)), 30));
+    await box.add(
+        _log(today.subtract(const Duration(days: 1)).add(const Duration(hours: 1)), 20));
+    await box.add(
+        _log(today.subtract(const Duration(days: 3)).add(const Duration(hours: 1)), 10));
+
+    final daily = await aggregator.dailyStudyTime();
+    expect(daily[today]?.inMinutes, 30);
+    expect(daily.length, 3);
+    expect(aggregator.currentStreak(), 2);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `SessionAggregator` service for session logs
- add `HistoryScreen` with charts and heatmap
- wire new screen into main navigation
- write tests for aggregator and empty state
- mark roadmap item as complete

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7d28e63c832ab3c1d7520245d20d