### PR TITLE
fix quiz result screen initState error

### DIFF
--- a/lib/quiz_result_screen.dart
+++ b/lib/quiz_result_screen.dart
@@ -38,7 +38,8 @@ class _QuizResultScreenState extends State<QuizResultScreen> {
     _stateBox = Hive.box<Map>(flashcardStateBoxName);
     _addStatsEntry().then((_) {
       if (mounted) {
-        WidgetsBinding.instance.addPostFrameCallback((_) => _showSummaryDialog());
+        WidgetsBinding.instance
+            .addPostFrameCallback((_) => _showSummaryDialog());
       }
     });
   }
@@ -73,11 +74,13 @@ class _QuizResultScreenState extends State<QuizResultScreen> {
       state['tagStats'] = statsMap;
       await _stateBox.put(card.id, state);
     }
+  }
+
+  // Shows summary dialog after quiz completion
 
   Future<void> _showSummaryDialog() async {
-    final accuracy = widget.words.isEmpty
-        ? 0
-        : widget.score / widget.words.length * 100;
+    final accuracy =
+        widget.words.isEmpty ? 0 : widget.score / widget.words.length * 100;
     await showDialog<void>(
       context: context,
       builder: (context) {


### PR DESCRIPTION
## Summary
- close `_addStatsEntry` properly in QuizResultScreen
- run `dart format`

## Testing
- `dart format --set-exit-if-changed .`
- `flutter analyze` *(fails: Unable to 'pub upgrade' flutter tool)*
- `flutter test` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_685e90aff1d8832ab813b8a31f4f354b