### PR TITLE
Add Firebase placeholders

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,76 @@
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+/// Default [FirebaseOptions] for the app.
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      case TargetPlatform.windows:
+        return windows;
+      case TargetPlatform.linux:
+        return linux;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not configured for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'TODO', // TODO: replace with real keys
+    appId: 'TODO',
+    messagingSenderId: 'TODO',
+    projectId: 'TODO',
+    authDomain: 'TODO',
+    storageBucket: 'TODO',
+    measurementId: 'TODO',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'TODO', // TODO: replace with real keys
+    appId: 'TODO',
+    messagingSenderId: 'TODO',
+    projectId: 'TODO',
+    storageBucket: 'TODO',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'TODO', // TODO: replace with real keys
+    appId: 'TODO',
+    messagingSenderId: 'TODO',
+    projectId: 'TODO',
+    iosBundleId: 'TODO',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'TODO', // TODO: replace with real keys
+    appId: 'TODO',
+    messagingSenderId: 'TODO',
+    projectId: 'TODO',
+    iosBundleId: 'TODO',
+  );
+
+  static const FirebaseOptions windows = FirebaseOptions(
+    apiKey: 'TODO', // TODO: replace with real keys
+    appId: 'TODO',
+    messagingSenderId: 'TODO',
+    projectId: 'TODO',
+  );
+
+  static const FirebaseOptions linux = FirebaseOptions(
+    apiKey: 'TODO', // TODO: replace with real keys
+    appId: 'TODO',
+    messagingSenderId: 'TODO',
+    projectId: 'TODO',
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,10 @@ dependencies:
   google_mobile_ads: ^3.0.0
   flutter_riverpod: ^2.5.0
   badges: ^3.1.2
+  firebase_core: ^3.6.0
+  firebase_crashlytics: ^4.0.0
+  firebase_analytics: ^12.1.0
+  flutter_local_notifications: ^17.0.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## Why
- prepare for Firebase integration

## What
- add firebase packages in `pubspec.yaml`
- generate `firebase_options.dart` with TODO keys

## How
- manual update of dependencies
- attempted `flutter pub get`, `flutter analyze`, and `flutter test` (environment lacks Flutter)


------
https://chatgpt.com/codex/tasks/task_e_685e99166188832ab81c9672a80b5b45