### PR TITLE
Add release build to CI

### DIFF
--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -19,3 +21,8 @@ jobs:
         run: flutter pub get
       - name: Run tests
         run: flutter test --coverage
+      - name: Build release APK
+        run: flutter build apk --release
+      - name: Upload Crashlytics symbols
+        run: ./gradlew app:uploadCrashlyticsSymbolFileRelease
+        working-directory: android


### PR DESCRIPTION
## Summary
- set `GOOGLE_APPLICATION_CREDENTIALS` from `FIREBASE_SERVICE_ACCOUNT`
- build release APK and upload Crashlytics symbols in CI

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*
- `dart format` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685eadc3f278832a892fc525b9dc6127