### PR TITLE
Add analytics opt-in widget test

### DIFF
--- a/test/analytics_opt_in_test.dart
+++ b/test/analytics_opt_in_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import 'package:tango/constants.dart';
+import 'package:tango/tabs_content/settings_tab_content.dart';
+import 'package:tango/analytics_provider.dart';
+import 'package:tango/theme_provider.dart';
+
+void main() {
+  late Directory dir;
+  late Box box;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    box = await Hive.openBox(settingsBoxName);
+  });
+
+  tearDown(() async {
+    await box.close();
+    await Hive.deleteBoxFromDisk(settingsBoxName);
+    await dir.delete(recursive: true);
+  });
+
+  testWidgets('analytics switch updates box and provider', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: ChangeNotifierProvider(
+          create: (_) => ThemeProvider(),
+          child: const MaterialApp(home: SettingsTabContent()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final finder = find.byType(SwitchListTile);
+    expect(tester.widget<SwitchListTile>(finder).value, isFalse);
+
+    await tester.tap(finder);
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<SwitchListTile>(finder).value, isTrue);
+    expect(box.get(AnalyticsNotifier.key), isTrue);
+  });
+}


### PR DESCRIPTION
## Why
To ensure the analytics switch persists state correctly.

## What
- new `analytics_opt_in_test.dart` verifying switch updates Hive and provider

## How
- use temporary Hive directory and `SettingsTabContent`

- `dart format`, `flutter analyze`, and `flutter test` couldn't run here


------
https://chatgpt.com/codex/tasks/task_e_685eaf0ffd28832a94dd8879968bf04a