### PR TITLE
fix dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   badges: ^3.1.2
   firebase_core: ^3.6.0
   firebase_crashlytics: ^4.0.0
-  firebase_analytics: ^12.1.0
+  firebase_analytics: ^11.5.0
   flutter_local_notifications: ^17.0.0
 
 


### PR DESCRIPTION
## Summary
- use a real `firebase_analytics` version so `pub get` can succeed

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb0c14dc4832a9f46b47707a7e666