### PR TITLE
Fix missing UMP package

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:google_user_messaging_platform/google_user_messaging_platform.dart';
+import 'package:user_messaging_platform/user_messaging_platform.dart';
 import 'firebase_options.dart';
 import 'main_screen.dart';
 import 'history_entry_model.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -791,10 +791,10 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  google_user_messaging_platform:
+  user_messaging_platform:
     dependency: "direct main"
     description:
-      name: google_user_messaging_platform
+      name: user_messaging_platform
       sha256: "0000000000000000000000000000000000000000000000000000000000000000"
       url: "https://pub.dev"
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   fl_chart: ^0.64.0
   http: ^0.13.6
   google_mobile_ads: ^4.0.0
-  google_user_messaging_platform: ^2.1.0
+  user_messaging_platform: ^2.1.0
   flutter_riverpod: ^2.5.0
   badges: ^3.1.2
   firebase_core: ^3.6.0


### PR DESCRIPTION
## Why
`flutter pub get` failed because `google_user_messaging_platform` does not exist on pub.dev.

## What
- replaced the dependency with `user_messaging_platform`
- updated import path in `main.dart`
- synced `pubspec.lock`

## How
- `dart format` *(failed: command not found)*
- `flutter pub get` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685ebf1f8588832abb510be2b838f0f1