### PR TITLE
Fix pubspec UMP version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -798,7 +798,7 @@ packages:
       sha256: "0000000000000000000000000000000000000000000000000000000000000000"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "1.3.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   fl_chart: ^0.64.0
   http: ^0.13.6
   google_mobile_ads: ^4.0.0
-  user_messaging_platform: ^2.1.0
+  user_messaging_platform: ^1.3.0
   flutter_riverpod: ^2.5.0
   badges: ^3.1.2
   firebase_core: ^3.6.0


### PR DESCRIPTION
## Why
Flutter `flutter pub get` failed due to unavailable `user_messaging_platform` version.

## What
- downgrade `user_messaging_platform` to `^1.3.0`
- update `pubspec.lock`

## How
N/A (dependencies only)

### Checklist
- [ ] `flutter analyze`
- [ ] `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_685ec465cd00832ab786a1abb73c940e