### PR TITLE
Fix ads config and tests

### DIFF
--- a/lib/ads_personalization_provider.dart
+++ b/lib/ads_personalization_provider.dart
@@ -28,10 +28,10 @@ class AdsPersonalizationNotifier extends StateNotifier<bool> {
   Future<void> _applyConfig(bool personalized) {
     if (personalized) {
       return MobileAds.instance
-          .updateRequestConfiguration(const RequestConfiguration());
+          .updateRequestConfiguration(RequestConfiguration());
     } else {
-      return MobileAds.instance.updateRequestConfiguration(const RequestConfiguration(
-        testDeviceIdentifiers: [],
+      return MobileAds.instance.updateRequestConfiguration(RequestConfiguration(
+        testDeviceIds: [],
         tagForChildDirectedTreatment: TagForChildDirectedTreatment.unspecified,
         maxAdContentRating: MaxAdContentRating.g,
       ));

--- a/test/ads_setting_test.dart
+++ b/test/ads_setting_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import 'package:hive/hive.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 
@@ -14,7 +15,7 @@ import 'package:tango/theme_provider.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   MobileAds.instance.updateRequestConfiguration(
-      const RequestConfiguration(testDeviceIdentifiers: ['TEST_DEVICE']));
+      RequestConfiguration(testDeviceIds: ['TEST_DEVICE']));
   MobileAds.instance.initialize();
 
   late Directory dir;

--- a/test/analytics_opt_in_test.dart
+++ b/test/analytics_opt_in_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import 'package:hive/hive.dart';
 
 import 'package:tango/constants.dart';

--- a/test/banner_visibility_test.dart
+++ b/test/banner_visibility_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import 'package:hive/hive.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 
@@ -14,7 +15,7 @@ import 'package:tango/models/quiz_stat.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   MobileAds.instance.updateRequestConfiguration(
-      const RequestConfiguration(testDeviceIdentifiers: ['TEST_DEVICE']));
+      RequestConfiguration(testDeviceIds: ['TEST_DEVICE']));
   MobileAds.instance.initialize();
 
   late Directory dir;

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -37,7 +37,7 @@ void main() {
     Hive.registerAdapter(ReviewQueueAdapter());
     logBox = await Hive.openBox<SessionLog>(sessionLogBoxName);
     statBox = await Hive.openBox<LearningStat>(LearningRepository.boxName);
-    boxQueue = await Hive.openBox(reviewQueueBoxName);
+    boxQueue = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     controller = StudySessionController(logBox, ReviewQueueService(boxQueue));
   });
 

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -20,7 +20,7 @@ void main() {
     Hive.registerAdapter(ReviewQueueAdapter());
     await Hive.openBox<SessionLog>(sessionLogBoxName);
     await Hive.openBox<LearningStat>(LearningRepository.boxName);
-    await Hive.openBox(reviewQueueBoxName);
+    await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
   });
 
   tearDownAll(() async {
@@ -48,7 +48,7 @@ void main() {
         overrides: [
           studySessionControllerProvider.overrideWith((ref) {
             final logBox = Hive.box<SessionLog>(sessionLogBoxName);
-            final queueBox = Hive.box(reviewQueueBoxName);
+            final queueBox = Hive.box<ReviewQueue>(reviewQueueBoxName);
             return StudySessionController(logBox, ReviewQueueService(queueBox));
           })
         ],


### PR DESCRIPTION
## Why
Fix failing tests due to API changes in google_mobile_ads and incorrect Hive box types.

## What
- remove const and update property names for RequestConfiguration
- correct generic types for Hive boxes in tests
- import provider package where ChangeNotifierProvider is used

## How
- `flutter analyze` and `flutter test` were attempted but flutter was unavailable in the environment.


------
https://chatgpt.com/codex/tasks/task_e_685ec608d3b4832ab5c6ec6e19ac6f4a