### PR TITLE
Fix build warnings

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
 import 'package:hive/hive.dart';
 
-import 'history_entry_model.dart';
 import 'word_list_query.dart';
 
 import 'flashcard_model.dart';

--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart'; // Hiveをインポート
 import 'flashcard_model.dart';
-import '../history_entry_model.dart'; // 閲覧履歴用のモデルをインポート (libフォルダ直下にある想定)
 import '../word_detail_controller.dart';
 import 'flashcard_repository.dart';
 import '../star_color.dart';


### PR DESCRIPTION
## Summary
- remove unused imports in flashcard_repository.dart
- remove unused imports in word_detail_content.dart

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f27a7d2a4832a82ae195f8f8ab149