### PR TITLE
Fix test initialization and widget errors

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -41,9 +41,14 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
     final prefs = await widget.prefsProvider();
     final index = prefs.getInt(_bookmarkKey) ?? 0;
     if (!mounted) return;
-    _pageController.jumpToPage(index);
-    setState(() {
-      _currentIndex = index;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (_pageController.hasClients) {
+        _pageController.jumpToPage(index);
+      }
+      setState(() {
+        _currentIndex = index;
+      });
     });
   }
 

--- a/test/ads_setting_test.dart
+++ b/test/ads_setting_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:provider/provider.dart';
+import 'package:provider/provider.dart' as provider_pkg;
 import 'package:hive/hive.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 
@@ -36,7 +36,7 @@ void main() {
   testWidgets('ads switch persists to hive', (tester) async {
     await tester.pumpWidget(
       ProviderScope(
-        child: ChangeNotifierProvider(
+        child: provider_pkg.ChangeNotifierProvider(
           create: (_) => ThemeProvider(),
           child: const MaterialApp(home: SettingsTabContent()),
         ),

--- a/test/analytics_opt_in_test.dart
+++ b/test/analytics_opt_in_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:provider/provider.dart';
+import 'package:provider/provider.dart' as provider_pkg;
 import 'package:hive/hive.dart';
 
 import 'package:tango/constants.dart';
@@ -30,7 +30,7 @@ void main() {
   testWidgets('analytics switch updates box and provider', (tester) async {
     await tester.pumpWidget(
       ProviderScope(
-        child: ChangeNotifierProvider(
+        child: provider_pkg.ChangeNotifierProvider(
           create: (_) => ThemeProvider(),
           child: const MaterialApp(home: SettingsTabContent()),
         ),

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -50,9 +50,15 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(ReviewQueueAdapter());
-    Hive.registerAdapter(LearningStatAdapter());
-    Hive.registerAdapter(WordAdapter());
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
+    if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
+      Hive.registerAdapter(WordAdapter());
+    }
     queueBox = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     favBox = await Hive.openBox<Map>(favoritesBoxName);
     statBox = await Hive.openBox<LearningStat>(LearningRepository.boxName);

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -13,7 +13,9 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(ReviewQueueAdapter());
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
     box = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     service = ReviewQueueService(box);
   });

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -14,7 +14,7 @@ void main() {
   late Directory dir;
   late Box<SessionLog> logBox;
   late Box<LearningStat> statBox;
-  late Box boxQueue;
+  late Box<ReviewQueue> boxQueue;
   late StudySessionController controller;
 
   Flashcard _card(String id) => Flashcard(
@@ -32,9 +32,15 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(SessionLogAdapter());
-    Hive.registerAdapter(LearningStatAdapter());
-    Hive.registerAdapter(ReviewQueueAdapter());
+    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+      Hive.registerAdapter(SessionLogAdapter());
+    }
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
     logBox = await Hive.openBox<SessionLog>(sessionLogBoxName);
     statBox = await Hive.openBox<LearningStat>(LearningRepository.boxName);
     boxQueue = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -15,15 +15,24 @@ import 'package:tango/study_start_sheet.dart';
 void main() {
   setUpAll(() async {
     Hive.init('./testdb');
-    Hive.registerAdapter(SessionLogAdapter());
-    Hive.registerAdapter(LearningStatAdapter());
-    Hive.registerAdapter(ReviewQueueAdapter());
+    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+      Hive.registerAdapter(SessionLogAdapter());
+    }
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
     await Hive.openBox<SessionLog>(sessionLogBoxName);
     await Hive.openBox<LearningStat>(LearningRepository.boxName);
     await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
   });
 
   tearDownAll(() async {
+    await Hive.box<SessionLog>(sessionLogBoxName).close();
+    await Hive.box<LearningStat>(LearningRepository.boxName).close();
+    await Hive.box<ReviewQueue>(reviewQueueBoxName).close();
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
@@ -42,7 +51,6 @@ void main() {
       );
 
   testWidgets('flow one word', (tester) async {
-    final words = [_card('1')];
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -52,12 +60,6 @@ void main() {
             return StudySessionController(logBox, ReviewQueueService(queueBox));
           })
         ],
-        child: const MaterialApp(home: Scaffold()),
-      ),
-    );
-
-    await tester.pumpWidget(
-      ProviderScope(
         child: MaterialApp(
           home: Builder(
             builder: (context) {

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -16,7 +16,9 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(SavedThemeModeAdapter());
+    if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
+      Hive.registerAdapter(SavedThemeModeAdapter());
+    }
     box = await Hive.openBox(settingsBoxName);
     notifier = ThemeModeNotifier(box);
     await notifier.load();

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -26,11 +26,16 @@ void main() {
   testWidgets('restores bookmark page', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 1});
     final prefs = await SharedPreferences.getInstance();
-    await tester.pumpWidget(MaterialApp(
-        home: WordbookScreen(
-      flashcards: cards,
-      prefsProvider: () async => prefs,
-    )));
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: WordbookScreen(
+            flashcards: cards,
+            prefsProvider: () async => prefs,
+          ),
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
     expect(find.text('現在 2 / 全 2'), findsOneWidget);
   });
@@ -38,11 +43,16 @@ void main() {
   testWidgets('saves bookmark on page change', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
     final prefs = await SharedPreferences.getInstance();
-    await tester.pumpWidget(MaterialApp(
-        home: WordbookScreen(
-      flashcards: cards,
-      prefsProvider: () async => prefs,
-    )));
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: WordbookScreen(
+            flashcards: cards,
+            prefsProvider: () async => prefs,
+          ),
+        ),
+      ),
+    );
     await tester.drag(find.byType(PageView), const Offset(-400, 0));
     await tester.pumpAndSettle();
     expect(prefs.getInt('bookmark_pageIndex'), 1);
@@ -51,11 +61,16 @@ void main() {
   testWidgets('search selects page and saves bookmark', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
     final prefs = await SharedPreferences.getInstance();
-    await tester.pumpWidget(MaterialApp(
-        home: WordbookScreen(
-      flashcards: cards,
-      prefsProvider: () async => prefs,
-    )));
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: WordbookScreen(
+            flashcards: cards,
+            prefsProvider: () async => prefs,
+          ),
+        ),
+      ),
+    );
 
     // Open search bottom sheet
     await tester.tap(find.byIcon(Icons.search));


### PR DESCRIPTION
## Summary
- resolve provider import collisions in tests
- avoid duplicate Hive adapter registration
- fix type in study_session_controller_test
- improve bookmark loading in WordbookScreen
- wrap tests with ProviderScope and adjust flow test

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2cc8e648832ab1312f4dff3d08ff