### PR TITLE
Fix interstitial ad display timing

### DIFF
--- a/lib/study_start_sheet.dart
+++ b/lib/study_start_sheet.dart
@@ -145,14 +145,13 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen> {
               Text('学習時間: ${state.startTime != null ? DateTime.now().difference(state.startTime!).inSeconds : 0}秒'),
               Text('正答率: $acc%'),
               ElevatedButton(
-                onPressed: () async {
+                onPressed: () {
                   final personalized =
                       ref.read(adsPersonalizationProvider);
-                  await AdService.showInterstitial(
-                      nonPersonalized: !personalized);
-                  if (mounted) {
-                    Navigator.of(context).pop();
-                  }
+                  Navigator.of(context).pop();
+                  AdService.showInterstitial(
+                    nonPersonalized: !personalized,
+                  );
                 },
                 child: const Text('閉じる'),
               )


### PR DESCRIPTION
## Why
- roadmap #8 called for showing interstitial ads only after the study-session end dialog is closed

## What
- move `AdService.showInterstitial` call after Navigator.pop

## How
- updated the closing button in `StudySessionScreen`
- `flutter analyze` and `flutter test` fail due to missing Flutter in the environment


------
https://chatgpt.com/codex/tasks/task_e_685f571d66d4832a9a014f80b1c747b1