### PR TITLE
feat: reload banner ads on personalization toggle

### DIFF
--- a/lib/ads_personalization_provider.dart
+++ b/lib/ads_personalization_provider.dart
@@ -4,9 +4,16 @@ import 'package:hive/hive.dart';
 
 import 'constants.dart';
 
-class AdsPersonalizationNotifier extends StateNotifier<bool> {
-  AdsPersonalizationNotifier(this._box) : super(false);
+final bannerReloadProvider = StateProvider<int>((ref) => 0);
 
+void reloadBannerAds(Ref ref) {
+  ref.read(bannerReloadProvider.notifier).state++;
+}
+
+class AdsPersonalizationNotifier extends StateNotifier<bool> {
+  AdsPersonalizationNotifier(this._box, this._ref) : super(false);
+
+  final Ref _ref;
   final Box _box;
   static const String key = 'adsPersonalized';
 
@@ -21,6 +28,11 @@ class AdsPersonalizationNotifier extends StateNotifier<bool> {
     state = value;
     await _box.put(key, value);
     await _applyConfig(value);
+  }
+
+  Future<void> toggle() async {
+    await setPersonalized(!state);
+    reloadBannerAds(_ref);
   }
 
   bool get hasValue => _box.containsKey(key);
@@ -42,7 +54,7 @@ class AdsPersonalizationNotifier extends StateNotifier<bool> {
 final adsPersonalizationProvider =
     StateNotifierProvider<AdsPersonalizationNotifier, bool>((ref) {
   final box = Hive.box(settingsBoxName);
-  final notifier = AdsPersonalizationNotifier(box);
+  final notifier = AdsPersonalizationNotifier(box, ref);
   notifier.load();
   return notifier;
 });

--- a/lib/quiz_result_screen.dart
+++ b/lib/quiz_result_screen.dart
@@ -35,6 +35,7 @@ class _QuizResultScreenState extends ConsumerState<QuizResultScreen> {
   late Box<Map> _stateBox;
   bool _showDescriptions = true;
   late BannerAd _bannerAd;
+  late ProviderSubscription<int> _bannerSub;
 
   @override
   void initState() {
@@ -44,6 +45,9 @@ class _QuizResultScreenState extends ConsumerState<QuizResultScreen> {
     final personalized = ref.read(adsPersonalizationProvider);
     _bannerAd = AdService.createBannerAd(nonPersonalized: !personalized)
       ..load();
+    _bannerSub = ref.listen<int>(bannerReloadProvider, (prev, next) {
+      _reloadBanner();
+    });
     _addStatsEntry().then((_) {
       if (mounted) {
         WidgetsBinding.instance
@@ -52,9 +56,18 @@ class _QuizResultScreenState extends ConsumerState<QuizResultScreen> {
     });
   }
 
+  void _reloadBanner() {
+    _bannerAd.dispose();
+    final personalized = ref.read(adsPersonalizationProvider);
+    _bannerAd = AdService.createBannerAd(nonPersonalized: !personalized)
+      ..load();
+    setState(() {});
+  }
+
   @override
   void dispose() {
     _bannerAd.dispose();
+    _bannerSub.close();
     super.dispose();
   }
 

--- a/lib/tabs_content/settings_tab_content.dart
+++ b/lib/tabs_content/settings_tab_content.dart
@@ -138,7 +138,7 @@ class _SettingsTabContentState extends ConsumerState<SettingsTabContent> {
           title: const Text('広告パーソナライズ'),
           value: adsPersonalized,
           onChanged: (val) async {
-            await adsNotifier.setPersonalized(val);
+            await adsNotifier.toggle();
           },
         ),
         if (!kReleaseMode)

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -26,6 +26,7 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
   late PageController _pageController;
   int _currentIndex = 0;
   late BannerAd _bannerAd;
+  late ProviderSubscription<int> _bannerSub;
 
   @override
   void initState() {
@@ -35,6 +36,17 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
     final personalized = ref.read(adsPersonalizationProvider);
     _bannerAd = AdService.createBannerAd(nonPersonalized: !personalized)
       ..load();
+    _bannerSub = ref.listen<int>(bannerReloadProvider, (prev, next) {
+      _reloadBanner();
+    });
+  }
+
+  void _reloadBanner() {
+    _bannerAd.dispose();
+    final personalized = ref.read(adsPersonalizationProvider);
+    _bannerAd = AdService.createBannerAd(nonPersonalized: !personalized)
+      ..load();
+    setState(() {});
   }
 
   Future<void> _loadBookmark() async {
@@ -79,6 +91,7 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
   @override
   void dispose() {
     _bannerAd.dispose();
+    _bannerSub.close();
     _pageController.dispose();
     super.dispose();
   }

--- a/test/banner_reload_test.dart
+++ b/test/banner_reload_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:tango/constants.dart';
+import 'package:tango/wordbook_screen.dart';
+import 'package:tango/flashcard_model.dart';
+import 'package:tango/ads_personalization_provider.dart';
+
+Flashcard _card(String id) => Flashcard(
+      id: id,
+      term: id,
+      reading: id,
+      description: 'd',
+      categoryLarge: 'A',
+      categoryMedium: 'B',
+      categorySmall: 'C',
+      categoryItem: 'D',
+      importance: 1,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  MobileAds.instance.updateRequestConfiguration(
+      RequestConfiguration(testDeviceIds: ['TEST_DEVICE']));
+  MobileAds.instance.initialize();
+
+  late Directory dir;
+  late Box box;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    box = await Hive.openBox(settingsBoxName);
+  });
+
+  tearDown(() async {
+    await box.close();
+    await Hive.deleteBoxFromDisk(settingsBoxName);
+    await dir.delete(recursive: true);
+  });
+
+  testWidgets('banner reloads after toggle', (tester) async {
+    final cards = [_card('1')];
+    final container = ProviderContainer();
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: WordbookScreen(
+            flashcards: cards,
+            prefsProvider: SharedPreferences.getInstance,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final firstWidget = tester.widget<AdWidget>(find.byType(AdWidget));
+
+    await container.read(adsPersonalizationProvider.notifier).toggle();
+    await tester.pumpAndSettle();
+
+    final secondWidget = tester.widget<AdWidget>(find.byType(AdWidget));
+    expect(identical(firstWidget.ad, secondWidget.ad), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- trigger banner reloads via bannerReloadProvider
- update AdsPersonalizationNotifier with toggle and ref
- listen for reloads in WordbookScreen and QuizResultScreen
- hook toggle switch to new notifier method
- add banner_reload_test

## Testing
- `dart format lib/ads_personalization_provider.dart lib/wordbook_screen.dart lib/quiz_result_screen.dart lib/tabs_content/settings_tab_content.dart test/banner_reload_test.dart` *(fails: `dart` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6fc17748832aac441d7bc0d9c4f2