### PR TITLE
feat: consent region gating

### DIFF
--- a/lib/ads/consent_manager.dart
+++ b/lib/ads/consent_manager.dart
@@ -1,0 +1,53 @@
+abstract class ConsentClient {
+  bool get isRequestLocationInEeaOrUnknown;
+  Future<void> requestConsentInfoUpdate(ConsentRequestParameters params);
+  Future<bool> isConsentFormAvailable();
+}
+
+abstract class ConsentFormPresenter {
+  Future<void> show();
+}
+
+class UmpConsentClient implements ConsentClient {
+  @override
+  bool get isRequestLocationInEeaOrUnknown =>
+      ConsentInformation.instance.isRequestLocationInEeaOrUnknown;
+
+  @override
+  Future<void> requestConsentInfoUpdate(ConsentRequestParameters params) {
+    return ConsentInformation.instance.requestConsentInfoUpdate(params);
+  }
+
+  @override
+  Future<bool> isConsentFormAvailable() {
+    return ConsentInformation.instance.isConsentFormAvailable();
+  }
+}
+
+class UmpConsentFormPresenter implements ConsentFormPresenter {
+  @override
+  Future<void> show() async {
+    try {
+      await UserMessagingPlatform.instance.showConsentFormIfRequired();
+    } catch (_) {
+      try {
+        await UserMessagingPlatform.instance.showConsentForm();
+      } catch (_) {}
+    }
+  }
+}
+
+Future<void> maybeShowConsentForm({
+  ConsentClient? consentClient,
+  ConsentFormPresenter? presenter,
+}) async {
+  final client = consentClient ?? UmpConsentClient();
+  final form = presenter ?? UmpConsentFormPresenter();
+  try {
+    await client.requestConsentInfoUpdate(const ConsentRequestParameters());
+  } catch (_) {}
+  if (client.isRequestLocationInEeaOrUnknown &&
+      await client.isConsentFormAvailable()) {
+    await form.show();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:user_messaging_platform/user_messaging_platform.dart';
+import 'ads/consent_manager.dart';
 import 'firebase_options.dart';
 import 'main_screen.dart';
 import 'history_entry_model.dart';
@@ -69,18 +70,7 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   await AdService.initialize();
-  // Support older user_messaging_platform versions lacking
-  // `showConsentFormIfRequired` by invoking dynamically.
-  try {
-    await (UserMessagingPlatform.instance as dynamic)
-        .showConsentFormIfRequired();
-  } catch (_) {
-    try {
-      await (UserMessagingPlatform.instance as dynamic).showConsentForm();
-    } catch (_) {
-      // ignore if the method is unavailable
-    }
-  }
+  await maybeShowConsentForm();
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
   await Hive.initFlutter();
 

--- a/test/consent_test.dart
+++ b/test/consent_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tango/ads/consent_manager.dart';
+import 'package:user_messaging_platform/user_messaging_platform.dart';
+
+class _FakeConsentClient implements ConsentClient {
+  _FakeConsentClient(this.isEea, this.available);
+  final bool isEea;
+  final bool available;
+  bool requested = false;
+
+  @override
+  bool get isRequestLocationInEeaOrUnknown => isEea;
+
+  @override
+  Future<bool> isConsentFormAvailable() async => available;
+
+  @override
+  Future<void> requestConsentInfoUpdate(ConsentRequestParameters params) async {
+    requested = true;
+  }
+}
+
+class _FakePresenter implements ConsentFormPresenter {
+  int calls = 0;
+  @override
+  Future<void> show() async {
+    calls++;
+  }
+}
+
+void main() {
+  test('skips when form unavailable', () async {
+    final client = _FakeConsentClient(true, false);
+    final presenter = _FakePresenter();
+    await maybeShowConsentForm(
+      consentClient: client,
+      presenter: presenter,
+    );
+    expect(presenter.calls, 0);
+    expect(client.requested, isTrue);
+  });
+}


### PR DESCRIPTION
## Why
Implement roadmap task #10 to display the UMP consent form only for users in the EU/EEA region.

## What
- added `ConsentManager` with injectable dependencies
- gated consent display behind region check and form availability
- created unit test using mocks to confirm skipping when form is unavailable

## How
- updated `main.dart` to call `maybeShowConsentForm`
- added new files and tests

### Checklist
- [ ] `flutter analyze`
- [ ] `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_685f715807ac832aa32b7cefe260bf19