### PR TITLE
feat: add iOS tracking permission

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,6 +45,8 @@
 	<true/>
         <key>UIApplicationSupportsIndirectInputEvents</key>
         <true/>
+        <key>NSUserTrackingUsageDescription</key>
+        <string>広告の最適化のためトラッキング許可を求めます。</string>
         <key>SKAdNetworkItems</key>
         <array>
                 <dict>


### PR DESCRIPTION
## Why
Implement roadmap item #11 to prepare for iOS ad tracking requirements.

## What
- add `NSUserTrackingUsageDescription` with Japanese explanation
- keep `SKAdNetworkItems` list with a network identifier

## How
- updated `ios/Runner/Info.plist`
- could not run `flutter analyze` and `flutter test` because `flutter` is not installed in the environment


------
https://chatgpt.com/codex/tasks/task_e_685f7a52b54c832a9e85d58c54677032