### PR TITLE
feat: load ad unit ids from env

### DIFF
--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -20,9 +20,15 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       - name: Run tests
-        run: flutter test --coverage
+        run: |
+          flutter test --coverage \
+            --dart-define BANNER_AD_UNIT_ID=ca-app-pub-3940256099942544/6300978111 \
+            --dart-define INTERSTITIAL_AD_UNIT_ID=ca-app-pub-3940256099942544/1033173712
       - name: Build release APK
-        run: flutter build apk --release
+        run: |
+          flutter build apk --release \
+            --dart-define BANNER_AD_UNIT_ID=${{ secrets.BANNER_AD_UNIT_ID }} \
+            --dart-define INTERSTITIAL_AD_UNIT_ID=${{ secrets.INTERSTITIAL_AD_UNIT_ID }}
       - name: Upload Crashlytics symbols
         run: ./gradlew app:uploadCrashlyticsSymbolFileRelease
         working-directory: android

--- a/.github/workflows/flutter-web-deploy.yml
+++ b/.github/workflows/flutter-web-deploy.yml
@@ -34,7 +34,11 @@ jobs:
 
       # Web ビルド
       - name: Build Flutter Web
-        run: flutter build web --base-href /tango/ --pwa-strategy=none
+        run: |
+          flutter build web \
+            --base-href /tango/ --pwa-strategy=none \
+            --dart-define BANNER_AD_UNIT_ID=${{ secrets.BANNER_AD_UNIT_ID }} \
+            --dart-define INTERSTITIAL_AD_UNIT_ID=${{ secrets.INTERSTITIAL_AD_UNIT_ID }}
 
       # GitHub Pages へデプロイ
       - name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -191,7 +191,20 @@ PR 作成 → CI 必須。
 
 レビュー後 squash & merge。
 
-11. ロードマップ（MVP 〜 β版）
+11. リリース手順
+
+アドネットワークの AdUnit ID は `--dart-define` で渡す。
+
+```bash
+flutter run \
+  --dart-define BANNER_AD_UNIT_ID=ca-app-pub-xxx/yyy \
+  --dart-define INTERSTITIAL_AD_UNIT_ID=ca-app-pub-xxx/zzz
+
+flutter build apk --release \
+  --dart-define BANNER_AD_UNIT_ID=ca-app-pub-xxx/yyy \
+  --dart-define INTERSTITIAL_AD_UNIT_ID=ca-app-pub-xxx/zzz
+```
+12. ロードマップ（MVP 〜 β版）
 
 No
 
@@ -250,7 +263,7 @@ firebase_crashlytics, firebase_analytics を導入。Analytics は設定画面�
 
 備考: 各タスクは feat/<task-name> ブランチ → PR → CI 通過 → squash & merge のフローで進行。
 
- ## 11. ロードマップ（MVP 〜 β版）
+## 12. ロードマップ（MVP 〜 β版）
  | No | タイトル                            | ざっくり内容                           | DoD                                |
  |----|------------------------------------|----------------------------------------|------------------------------------|
  | 1  | WordbookScreen MVP                 | …                                      | …                                  |
@@ -272,7 +285,7 @@ firebase_crashlytics, firebase_analytics を導入。Analytics は設定画面�
 
 
 
-12. ライセンス. ライセンス
+13. ライセンス. ライセンス
 
 MIT © 2025 Izumoto Hayato
 

--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:flutter/foundation.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 
 class AdService {
@@ -7,16 +6,11 @@ class AdService {
     return MobileAds.instance.initialize();
   }
 
-  static const String _releaseBannerAdUnitId = 'ca-app-pub-xxxxxxxxxxxxxxxx/1111111111';
-  static const String _releaseInterstitialAdUnitId = 'ca-app-pub-xxxxxxxxxxxxxxxx/2222222222';
-
-  static String get bannerAdUnitId => kReleaseMode
-      ? _releaseBannerAdUnitId
-      : 'ca-app-pub-3940256099942544/6300978111';
-
-  static String get interstitialAdUnitId => kReleaseMode
-      ? _releaseInterstitialAdUnitId
-      : 'ca-app-pub-3940256099942544/1033173712';
+  /// Ad unit IDs are provided via `--dart-define`.
+  static const String bannerAdUnitId =
+      String.fromEnvironment('BANNER_AD_UNIT_ID');
+  static const String interstitialAdUnitId =
+      String.fromEnvironment('INTERSTITIAL_AD_UNIT_ID');
 
   static BannerAd createBannerAd({String? adUnitId, bool nonPersonalized = false}) {
     return BannerAd(


### PR DESCRIPTION
## Summary
- make AdService read ad unit IDs from `--dart-define`
- pass ad unit IDs to CI builds and tests
- document release procedure for dart-define

## Testing
- `dart format lib/services/ad_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f825d3324832a9f2139066a2b78c0