### PR TITLE
Implement roadmap #14 test improvements

### DIFF
--- a/lib/services/aggregator.dart
+++ b/lib/services/aggregator.dart
@@ -5,9 +5,13 @@ import '../constants.dart';
 
 class SessionAggregator {
   final Box<SessionLog> _box;
+  final DateTime Function() _now;
 
-  SessionAggregator([Box<SessionLog>? box])
-      : _box = box ?? Hive.box<SessionLog>(sessionLogBoxName);
+  SessionAggregator([
+    Box<SessionLog>? box,
+    DateTime Function()? now,
+  ])  : _box = box ?? Hive.box<SessionLog>(sessionLogBoxName),
+        _now = now ?? DateTime.now;
 
   Future<Map<DateTime, Duration>> dailyStudyTime({
     DateTime? from,
@@ -17,7 +21,7 @@ class SessionAggregator {
     if (logs.isEmpty) return {};
     final start = from ??
         logs.map((e) => e.startTime).reduce((a, b) => a.isBefore(b) ? a : b);
-    final end = to ?? DateTime.now();
+    final end = to ?? _now();
     final Map<DateTime, Duration> result = {};
     for (final log in logs) {
       if (log.startTime.isBefore(start) || log.startTime.isAfter(end)) continue;
@@ -33,7 +37,7 @@ class SessionAggregator {
       return DateTime(e.startTime.year, e.startTime.month, e.startTime.day);
     }).toSet();
     int streak = 0;
-    DateTime day = DateTime.now();
+    DateTime day = _now();
     while (true) {
       final d = DateTime(day.year, day.month, day.day);
       if (dates.contains(d)) {

--- a/test/banner_visibility_test.dart
+++ b/test/banner_visibility_test.dart
@@ -14,9 +14,7 @@ import 'package:tango/models/quiz_stat.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  MobileAds.instance.updateRequestConfiguration(
-      RequestConfiguration(testDeviceIds: ['TEST_DEVICE']));
-  MobileAds.instance.initialize();
+  TestAdManager.initialize();
 
   late Directory dir;
   late Box<QuizStat> statsBox;
@@ -64,7 +62,7 @@ void main() {
         ),
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
     expect(find.byType(AdWidget), findsOneWidget);
   });
 }

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -9,6 +9,7 @@ void main() {
   late Directory dir;
   late Box<SessionLog> box;
   late SessionAggregator aggregator;
+  late DateTime fixedNow;
 
   SessionLog _log(DateTime start, int minutes) => SessionLog(
         startTime: start,
@@ -18,11 +19,12 @@ void main() {
       );
 
   setUp(() async {
+    fixedNow = DateTime(2025, 1, 15, 12);
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
     Hive.registerAdapter(SessionLogAdapter());
     box = await Hive.openBox<SessionLog>(sessionLogBoxName);
-    aggregator = SessionAggregator(box);
+    aggregator = SessionAggregator(box, () => fixedNow);
   });
 
   tearDown(() async {
@@ -32,8 +34,7 @@ void main() {
   });
 
   test('aggregates and streak', () async {
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
+    final today = DateTime(fixedNow.year, fixedNow.month, fixedNow.day);
     await box.add(_log(today.add(const Duration(hours: 1)), 30));
     await box.add(
         _log(today.subtract(const Duration(days: 1)).add(const Duration(hours: 1)), 20));


### PR DESCRIPTION
## Why
Roadmap item #14 requests test stability improvements.

## What
- add injectable time provider to `SessionAggregator`
- use fixed time in `session_aggregator_test`
- initialize ads for tests with `TestAdManager` and shorter pump

## How
- `SessionAggregator` constructor now accepts `[Box?, DateTime Function()?]`
- tests updated accordingly

Closes #14

------
https://chatgpt.com/codex/tasks/task_e_685f8a840db0832a85f47e9bbd1a1cd7