### PR TITLE
Fix build errors for web

### DIFF
--- a/lib/ads/consent_manager.dart
+++ b/lib/ads/consent_manager.dart
@@ -1,3 +1,5 @@
+import 'package:user_messaging_platform/user_messaging_platform.dart';
+
 abstract class ConsentClient {
   bool get isRequestLocationInEeaOrUnknown;
   Future<void> requestConsentInfoUpdate(ConsentRequestParameters params);

--- a/lib/quiz_result_screen.dart
+++ b/lib/quiz_result_screen.dart
@@ -35,7 +35,6 @@ class _QuizResultScreenState extends ConsumerState<QuizResultScreen> {
   late Box<Map> _stateBox;
   bool _showDescriptions = true;
   late BannerAd _bannerAd;
-  late ProviderSubscription<int> _bannerSub;
 
   @override
   void initState() {
@@ -45,7 +44,7 @@ class _QuizResultScreenState extends ConsumerState<QuizResultScreen> {
     final personalized = ref.read(adsPersonalizationProvider);
     _bannerAd = AdService.createBannerAd(nonPersonalized: !personalized)
       ..load();
-    _bannerSub = ref.listen<int>(bannerReloadProvider, (prev, next) {
+    ref.listen<int>(bannerReloadProvider, (prev, next) {
       _reloadBanner();
     });
     _addStatsEntry().then((_) {
@@ -67,7 +66,6 @@ class _QuizResultScreenState extends ConsumerState<QuizResultScreen> {
   @override
   void dispose() {
     _bannerAd.dispose();
-    _bannerSub.close();
     super.dispose();
   }
 

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -26,7 +26,6 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
   late PageController _pageController;
   int _currentIndex = 0;
   late BannerAd _bannerAd;
-  late ProviderSubscription<int> _bannerSub;
 
   @override
   void initState() {
@@ -36,7 +35,7 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
     final personalized = ref.read(adsPersonalizationProvider);
     _bannerAd = AdService.createBannerAd(nonPersonalized: !personalized)
       ..load();
-    _bannerSub = ref.listen<int>(bannerReloadProvider, (prev, next) {
+    ref.listen<int>(bannerReloadProvider, (prev, next) {
       _reloadBanner();
     });
   }
@@ -91,7 +90,6 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
   @override
   void dispose() {
     _bannerAd.dispose();
-    _bannerSub.close();
     _pageController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Why
- web build failed because consent manager lacked imports and Riverpod API changed

## What
- add user messaging platform import
- update banner ad listeners for new Riverpod API

## How
- `dart format`
- `flutter analyze`
- `flutter test`



------
https://chatgpt.com/codex/tasks/task_e_685f8d1bc5d4832aa5007901a8aceabd