### PR TITLE
Fix web build by stubbing consent manager

### DIFF
--- a/lib/ads/consent_manager.dart
+++ b/lib/ads/consent_manager.dart
@@ -1,8 +1,9 @@
-import 'package:user_messaging_platform/user_messaging_platform.dart';
+import 'consent_manager_io.dart'
+    if (dart.library.html) 'consent_manager_web.dart' as impl;
 
 abstract class ConsentClient {
   bool get isRequestLocationInEeaOrUnknown;
-  Future<void> requestConsentInfoUpdate(ConsentRequestParameters params);
+  Future<void> requestConsentInfoUpdate();
   Future<bool> isConsentFormAvailable();
 }
 
@@ -10,46 +11,11 @@ abstract class ConsentFormPresenter {
   Future<void> show();
 }
 
-class UmpConsentClient implements ConsentClient {
-  @override
-  bool get isRequestLocationInEeaOrUnknown =>
-      ConsentInformation.instance.isRequestLocationInEeaOrUnknown;
-
-  @override
-  Future<void> requestConsentInfoUpdate(ConsentRequestParameters params) {
-    return ConsentInformation.instance.requestConsentInfoUpdate(params);
-  }
-
-  @override
-  Future<bool> isConsentFormAvailable() {
-    return ConsentInformation.instance.isConsentFormAvailable();
-  }
-}
-
-class UmpConsentFormPresenter implements ConsentFormPresenter {
-  @override
-  Future<void> show() async {
-    try {
-      await UserMessagingPlatform.instance.showConsentFormIfRequired();
-    } catch (_) {
-      try {
-        await UserMessagingPlatform.instance.showConsentForm();
-      } catch (_) {}
-    }
-  }
-}
-
 Future<void> maybeShowConsentForm({
   ConsentClient? consentClient,
   ConsentFormPresenter? presenter,
-}) async {
-  final client = consentClient ?? UmpConsentClient();
-  final form = presenter ?? UmpConsentFormPresenter();
-  try {
-    await client.requestConsentInfoUpdate(const ConsentRequestParameters());
-  } catch (_) {}
-  if (client.isRequestLocationInEeaOrUnknown &&
-      await client.isConsentFormAvailable()) {
-    await form.show();
-  }
-}
+}) =>
+    impl.maybeShowConsentForm(
+      consentClient: consentClient,
+      presenter: presenter,
+    );

--- a/lib/ads/consent_manager_io.dart
+++ b/lib/ads/consent_manager_io.dart
@@ -1,0 +1,47 @@
+import 'package:user_messaging_platform/user_messaging_platform.dart';
+import 'consent_manager.dart';
+
+class UmpConsentClient implements ConsentClient {
+  @override
+  bool get isRequestLocationInEeaOrUnknown =>
+      ConsentInformation.instance.isRequestLocationInEeaOrUnknown;
+
+  @override
+  Future<void> requestConsentInfoUpdate() {
+    return ConsentInformation.instance
+        .requestConsentInfoUpdate(const ConsentRequestParameters());
+  }
+
+  @override
+  Future<bool> isConsentFormAvailable() {
+    return ConsentInformation.instance.isConsentFormAvailable();
+  }
+}
+
+class UmpConsentFormPresenter implements ConsentFormPresenter {
+  @override
+  Future<void> show() async {
+    try {
+      await UserMessagingPlatform.instance.showConsentFormIfRequired();
+    } catch (_) {
+      try {
+        await UserMessagingPlatform.instance.showConsentForm();
+      } catch (_) {}
+    }
+  }
+}
+
+Future<void> maybeShowConsentForm({
+  ConsentClient? consentClient,
+  ConsentFormPresenter? presenter,
+}) async {
+  final client = consentClient ?? UmpConsentClient();
+  final form = presenter ?? UmpConsentFormPresenter();
+  try {
+    await client.requestConsentInfoUpdate();
+  } catch (_) {}
+  if (client.isRequestLocationInEeaOrUnknown &&
+      await client.isConsentFormAvailable()) {
+    await form.show();
+  }
+}

--- a/lib/ads/consent_manager_web.dart
+++ b/lib/ads/consent_manager_web.dart
@@ -1,0 +1,8 @@
+import 'consent_manager.dart';
+
+Future<void> maybeShowConsentForm({
+  ConsentClient? consentClient,
+  ConsentFormPresenter? presenter,
+}) async {
+  // Consent handling is not required on web.
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:user_messaging_platform/user_messaging_platform.dart';
 import 'ads/consent_manager.dart';
 import 'firebase_options.dart';
 import 'main_screen.dart';

--- a/test/consent_test.dart
+++ b/test/consent_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tango/ads/consent_manager.dart';
-import 'package:user_messaging_platform/user_messaging_platform.dart';
 
 class _FakeConsentClient implements ConsentClient {
   _FakeConsentClient(this.isEea, this.available);
@@ -15,7 +14,7 @@ class _FakeConsentClient implements ConsentClient {
   Future<bool> isConsentFormAvailable() async => available;
 
   @override
-  Future<void> requestConsentInfoUpdate(ConsentRequestParameters params) async {
+  Future<void> requestConsentInfoUpdate() async {
     requested = true;
   }
 }


### PR DESCRIPTION
## Why
Web compilation failed because `consent_manager.dart` referenced `user_messaging_platform` APIs that are not available on the web implementation.

## What
- added platform specific implementation for consent manager
- removed direct dependency on `user_messaging_platform` from tests and main

## How
- `consent_manager.dart` now uses conditional imports to select a web stub or the real implementation
- updated test stubs and removed unused import

## Checklist
- [ ] `flutter analyze`
- [ ] `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_685f900e33c4832a8aff8c5f8d99131b