### PR TITLE
Fix consent manager and tests

### DIFF
--- a/lib/ads/consent_manager_io.dart
+++ b/lib/ads/consent_manager_io.dart
@@ -2,30 +2,34 @@ import 'package:user_messaging_platform/user_messaging_platform.dart';
 import 'consent_manager.dart';
 
 class UmpConsentClient implements ConsentClient {
+  final ConsentInformation _info =
+      UserMessagingPlatform.instance.consentInfo;
+
   @override
   bool get isRequestLocationInEeaOrUnknown =>
-      ConsentInformation.instance.isRequestLocationInEeaOrUnknown;
+      _info.isRequestLocationInEeaOrUnknown;
 
   @override
   Future<void> requestConsentInfoUpdate() {
-    return ConsentInformation.instance
-        .requestConsentInfoUpdate(const ConsentRequestParameters());
+    return _info.requestConsentInfoUpdate(ConsentRequestParameters());
   }
 
   @override
   Future<bool> isConsentFormAvailable() {
-    return ConsentInformation.instance.isConsentFormAvailable();
+    return _info.isConsentFormAvailable();
   }
 }
 
 class UmpConsentFormPresenter implements ConsentFormPresenter {
+  final ConsentForm _form = UserMessagingPlatform.instance.consentForm;
+
   @override
   Future<void> show() async {
     try {
-      await UserMessagingPlatform.instance.showConsentFormIfRequired();
+      await _form.loadAndShowConsentFormIfRequired();
     } catch (_) {
       try {
-        await UserMessagingPlatform.instance.showConsentForm();
+        await _form.show();
       } catch (_) {}
     }
   }

--- a/test/banner_visibility_test.dart
+++ b/test/banner_visibility_test.dart
@@ -14,7 +14,7 @@ import 'package:tango/models/quiz_stat.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  TestAdManager.initialize();
+  MobileAds.instance.initialize();
 
   late Directory dir;
   late Box<QuizStat> statsBox;

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/wordbook_screen.dart';


### PR DESCRIPTION
## Summary
- update consent manager for latest UMP API
- update banner visibility test for new ad API
- fix imports in wordbook screen test

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9aabfdd0832a9c2954580d6b06f3