### PR TITLE
fix failing tests

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -89,6 +89,10 @@ class FlashcardRepository {
     if (_cache != null) {
       return _cache!;
     }
+    if (_dataSource is! LocalFlashcardDataSource) {
+      _cache = await _dataSource.loadAll();
+      return _cache!;
+    }
     await _ensureRepos();
     final words = _wordRepo!.list();
     final stats = {for (var s in _learningRepo!.all()) s.wordId: s};

--- a/lib/quiz_in_progress_screen.dart
+++ b/lib/quiz_in_progress_screen.dart
@@ -126,13 +126,14 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
     await repo.markReviewed(id);
   }
 
-  void _onSelect(String term) {
+  Future<void> _onSelect(String term) async {
     if (_answered) return;
     _selectedTerm = term;
-    bool correct = term == _currentFlashcard.term;
+    final correct = term == _currentFlashcard.term;
     if (correct) _score++;
     _answerResults.add(correct);
-    _recordAnswer(correct);
+    await _recordAnswer(correct);
+    if (!mounted) return;
     setState(() {
       _answered = true;
     });
@@ -208,7 +209,9 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
     return SizedBox(
       width: double.infinity,
       child: ElevatedButton(
-        onPressed: () => _onSelect(card.term),
+        onPressed: () {
+          _onSelect(card.term);
+        },
         child: Text(card.term),
       ),
     );

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -52,14 +52,13 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
     final prefs = await widget.prefsProvider();
     final index = prefs.getInt(_bookmarkKey) ?? 0;
     if (!mounted) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      if (_pageController.hasClients) {
-        _pageController.jumpToPage(index);
-      }
-      setState(() {
-        _currentIndex = index;
-      });
+    await Future<void>.delayed(Duration.zero);
+    if (!mounted) return;
+    if (_pageController.hasClients) {
+      _pageController.jumpToPage(index);
+    }
+    setState(() {
+      _currentIndex = index;
     });
   }
 

--- a/test/analytics_opt_in_test.dart
+++ b/test/analytics_opt_in_test.dart
@@ -38,7 +38,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final finder = find.byType(SwitchListTile);
+    final finder = find.widgetWithText(SwitchListTile, 'Analytics');
     expect(tester.widget<SwitchListTile>(finder).value, isFalse);
 
     await tester.tap(finder);


### PR DESCRIPTION
## Summary
- fix async handling in `QuizInProgressScreen`
- ensure bookmark loads reliably in `WordbookScreen`
- avoid Hive dependency when a custom `FlashcardDataSource` is used
- update analytics opt‑in test finder

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb5d1c85c832a8fe4818be73bd91a