### PR TITLE
Fix wordbook bookmark page restore

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -52,11 +52,10 @@ class _WordbookScreenState extends ConsumerState<WordbookScreen> {
     final prefs = await widget.prefsProvider();
     final index = prefs.getInt(_bookmarkKey) ?? 0;
     if (!mounted) return;
-    await Future<void>.delayed(Duration.zero);
-    if (!mounted) return;
-    if (_pageController.hasClients) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_pageController.hasClients) return;
       _pageController.jumpToPage(index);
-    }
+    });
     setState(() {
       _currentIndex = index;
     });


### PR DESCRIPTION
## Summary
- address page bookmark restoration in `WordbookScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcbd35958832a96bf36401865f561