### PR TITLE
fix: warn when Firebase options missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ dart run build_runner build --delete-conflicting-outputs
 
 flutter run -d chrome もしくはシミュレータ。
 
+lib/firebase_options.dart の "TODO" を Firebase コンソールで取得した
+apiKey や appId など実際の値に置き換える。
+
 9. コーディングガイドライン
 
 flutter_lints 3 に準拠。

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,20 @@ import 'services/ad_service.dart';
 const _secureKeyName = 'hive_encryption_key';
 const _secureStorage = FlutterSecureStorage();
 
+void _validateFirebaseOptions(FirebaseOptions options) {
+  final values = [
+    options.apiKey,
+    options.appId,
+    options.messagingSenderId,
+    options.projectId,
+  ];
+  if (values.any((v) => v == 'TODO')) {
+    throw StateError(
+      'Firebase options are not configured. Replace TODO values in lib/firebase_options.dart.',
+    );
+  }
+}
+
 Future<List<int>> _getEncryptionKey() async {
   try {
     final stored = await _secureStorage.read(key: _secureKeyName);
@@ -65,8 +79,10 @@ Future<Box<T>> _openBoxWithMigration<T>(
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final options = DefaultFirebaseOptions.currentPlatform;
+  _validateFirebaseOptions(options);
   await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
+    options: options,
   );
   await AdService.initialize();
   await maybeShowConsentForm();


### PR DESCRIPTION
## Why
Flutter app crashed with a blank screen when `FirebaseOptions` remained with `TODO` values. This confused developers during setup.

## What
- added `_validateFirebaseOptions` and called it before `Firebase.initializeApp`
- documented the need to replace TODO values in `firebase_options.dart` in the setup section

## How
- `dart format`
- `flutter analyze` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcf634e0c832abd4d9371487b01a5