### PR TITLE
Fix braces in QuizResultScreen

### DIFF
--- a/lib/quiz_result_screen.dart
+++ b/lib/quiz_result_screen.dart
@@ -99,6 +99,9 @@ class _QuizResultScreenState extends ConsumerState<QuizResultScreen> {
       await _stateBox.put(card.id, state);
     }
 
+    // end of for loop
+  }
+
   Future<void> _showSummaryDialog() async {
     final accuracy = widget.words.isEmpty
         ? 0


### PR DESCRIPTION
## Why
A revert left a missing closing brace in `QuizResultScreenState` causing build errors.

## What
- closed `_addStatsEntry` method properly

## How
No tests could be executed because Flutter and Dart are unavailable in the environment.

------
https://chatgpt.com/codex/tasks/task_e_686132dbcf0c832a9bf9cf203a6fda7f