### PR TITLE
fix: type ReviewQueue box in test

### DIFF
--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -14,7 +14,7 @@ void main() {
   late Directory dir;
   late Box<SessionLog> logBox;
   late Box<LearningStat> statBox;
-  late Box boxQueue;
+  late Box<ReviewQueue> boxQueue;
   late StudySessionController controller;
 
   Flashcard _card(String id) => Flashcard(
@@ -37,7 +37,7 @@ void main() {
     Hive.registerAdapter(ReviewQueueAdapter());
     logBox = await Hive.openBox<SessionLog>(sessionLogBoxName);
     statBox = await Hive.openBox<LearningStat>(LearningRepository.boxName);
-    boxQueue = await Hive.openBox(reviewQueueBoxName);
+    boxQueue = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     controller = StudySessionController(logBox, ReviewQueueService(boxQueue));
   });
 


### PR DESCRIPTION
## Why
`study_session_controller_test` instantiated `ReviewQueueService` with a `Box` lacking a generic type, which conflicted with the service constructor expecting `Box<ReviewQueue>`.

## What
- specify `Box<ReviewQueue>` type for `boxQueue`
- open the Hive box using the same generic

## How
- edited `test/study_session_controller_test.dart`



------
https://chatgpt.com/codex/tasks/task_e_686239402b38832a97ba6489e9b98595