### PR TITLE
Fix review queue box type in session flow test

### DIFF
--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -20,7 +20,7 @@ void main() {
     Hive.registerAdapter(ReviewQueueAdapter());
     await Hive.openBox<SessionLog>(sessionLogBoxName);
     await Hive.openBox<LearningStat>(LearningRepository.boxName);
-    await Hive.openBox(reviewQueueBoxName);
+    await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
   });
 
   tearDownAll(() async {
@@ -48,7 +48,7 @@ void main() {
         overrides: [
           studySessionControllerProvider.overrideWith((ref) {
             final logBox = Hive.box<SessionLog>(sessionLogBoxName);
-            final queueBox = Hive.box(reviewQueueBoxName);
+            final queueBox = Hive.box<ReviewQueue>(reviewQueueBoxName);
             return StudySessionController(logBox, ReviewQueueService(queueBox));
           })
         ],


### PR DESCRIPTION
## Why
The study session flow test opened the review queue Hive box without specifying its type, causing runtime issues from `Box<dynamic>` vs `Box<ReviewQueue>`.

## What
- open `reviewQueueBoxName` with `Hive.openBox<ReviewQueue>`
- access the box using `Hive.box<ReviewQueue>`

## How
- no behavior changes, only test fixes


------
https://chatgpt.com/codex/tasks/task_e_686248b6058c832aa35fe1db24676a36