### PR TITLE
Add favorite filters to word list

### DIFF
--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -5,6 +5,7 @@ import '../flashcard_model.dart';
 import '../word_list_query.dart';
 import '../review_service.dart';
 import '../word_query_sheet.dart';
+import '../star_color.dart';
 
 /// Provider storing the list of words for the current [ReviewMode].
 final wordListForModeProvider = StateProvider<List<Flashcard>?>(
@@ -95,6 +96,61 @@ class WordListTabContentState extends ConsumerState<WordListTabContent> {
                               ..remove(WordFilter.wrongOnly);
                             ref.read(currentQueryProvider.notifier).state =
                                 query.copyWith(filters: newFilters);
+                          },
+                        ),
+                      ),
+                    if (query.favoritesOnly)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 4),
+                        child: InputChip(
+                          label: const Text('お気に入り'),
+                          onDeleted: () {
+                            ref.read(currentQueryProvider.notifier).state =
+                                query.copyWith(
+                                    favoritesOnly: false,
+                                    starFilters: const {});
+                          },
+                        ),
+                      ),
+                    if (query.favoritesOnly &&
+                        query.starFilters.contains(StarColor.red))
+                      Padding(
+                        padding: const EdgeInsets.only(right: 4),
+                        child: InputChip(
+                          label: const Text('赤星'),
+                          onDeleted: () {
+                            final colors = {...query.starFilters}
+                              ..remove(StarColor.red);
+                            ref.read(currentQueryProvider.notifier).state =
+                                query.copyWith(starFilters: colors);
+                          },
+                        ),
+                      ),
+                    if (query.favoritesOnly &&
+                        query.starFilters.contains(StarColor.yellow))
+                      Padding(
+                        padding: const EdgeInsets.only(right: 4),
+                        child: InputChip(
+                          label: const Text('黄星'),
+                          onDeleted: () {
+                            final colors = {...query.starFilters}
+                              ..remove(StarColor.yellow);
+                            ref.read(currentQueryProvider.notifier).state =
+                                query.copyWith(starFilters: colors);
+                          },
+                        ),
+                      ),
+                    if (query.favoritesOnly &&
+                        query.starFilters.contains(StarColor.blue))
+                      Padding(
+                        padding: const EdgeInsets.only(right: 4),
+                        child: InputChip(
+                          label: const Text('青星'),
+                          onDeleted: () {
+                            final colors = {...query.starFilters}
+                              ..remove(StarColor.blue);
+                            ref.read(currentQueryProvider.notifier).state =
+                                query.copyWith(starFilters: colors);
                           },
                         ),
                       ),

--- a/lib/word_query_sheet.dart
+++ b/lib/word_query_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'word_list_query.dart';
+import 'star_color.dart';
 
 /// Bottom sheet widget for editing [WordListQuery].
 class WordQuerySheet extends StatefulWidget {
@@ -14,18 +15,47 @@ class WordQuerySheet extends StatefulWidget {
 class _WordQuerySheetState extends State<WordQuerySheet> {
   late TextEditingController _controller;
   late Set<WordFilter> _filters;
+  late bool _favoritesOnly;
+  late Set<StarColor> _starFilters;
+  late bool _useAndFilter;
 
   @override
   void initState() {
     super.initState();
     _filters = {...widget.initial.filters};
     _controller = TextEditingController(text: widget.initial.searchText);
+    _favoritesOnly = widget.initial.favoritesOnly;
+    _starFilters = {...widget.initial.starFilters};
+    _useAndFilter = widget.initial.useAndFilter;
   }
 
   @override
   void dispose() {
     _controller.dispose();
     super.dispose();
+  }
+
+  void _toggleStar(StarColor color) {
+    setState(() {
+      if (_starFilters.contains(color)) {
+        _starFilters.remove(color);
+      } else {
+        _starFilters.add(color);
+      }
+    });
+  }
+
+  Widget _buildFilterStar(StarColor color, Color activeColor) {
+    final selected = _starFilters.contains(color);
+    return IconButton(
+      icon: Icon(
+        selected ? Icons.star : Icons.star_border,
+        color: selected ? activeColor : Theme.of(context).colorScheme.outline,
+        size: 24,
+      ),
+      onPressed: () => _toggleStar(color),
+      tooltip: '${color.label}星で絞り込む',
+    );
   }
 
   @override
@@ -83,6 +113,46 @@ class _WordQuerySheetState extends State<WordQuerySheet> {
                   ],
                 ),
               ),
+              SwitchListTile(
+                title: const Text('お気に入りのみ'),
+                value: _favoritesOnly,
+                onChanged: (val) => setState(() => _favoritesOnly = val),
+              ),
+              if (_favoritesOnly)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16, vertical: 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      ToggleButtons(
+                        isSelected: [_useAndFilter, !_useAndFilter],
+                        onPressed: (index) {
+                          setState(() {
+                            _useAndFilter = index == 0;
+                          });
+                        },
+                        children: const [
+                          Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 8),
+                            child: Text('AND'),
+                          ),
+                          Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 8),
+                            child: Text('OR'),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(width: 8),
+                      _buildFilterStar(
+                          StarColor.red, Theme.of(context).colorScheme.error),
+                      _buildFilterStar(StarColor.yellow,
+                          Theme.of(context).colorScheme.secondary),
+                      _buildFilterStar(
+                          StarColor.blue, Theme.of(context).colorScheme.primary),
+                    ],
+                  ),
+                ),
               Padding(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -95,6 +165,9 @@ class _WordQuerySheetState extends State<WordQuerySheet> {
                           widget.initial.copyWith(
                             searchText: _controller.text,
                             filters: _filters,
+                            favoritesOnly: _favoritesOnly,
+                            starFilters: _starFilters,
+                            useAndFilter: _useAndFilter,
                           ),
                         );
                       },


### PR DESCRIPTION
## Summary
- integrate star color filters in `WordListQuery`
- extend `WordQuerySheet` UI with favorite filters
- show favorite chips in `WordListTabContent`

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862508900a4832abdde8ccf1463fd61