### PR TITLE
Replace home screen with word list

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -41,7 +41,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   String _getAppBarTitle() {
     switch (_currentScreen) {
       case AppScreen.home:
-        return 'ホーム';
+        return '単語一覧';
       case AppScreen.wordList:
         return '単語一覧';
       case AppScreen.wordDetail:
@@ -80,9 +80,14 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   Widget _buildCurrentScreenContent() {
     switch (_currentScreen) {
       case AppScreen.home:
-        return HomeTabContent(
-          key: const ValueKey("HomeTabContent"),
-          navigateTo: _navigateTo,
+        return WordListTabContent(
+          key: _wordListKey,
+          onWordTap: (flashcards, index) {
+            _navigateTo(
+              AppScreen.wordDetail,
+              args: ScreenArguments(flashcards: flashcards, initialIndex: index),
+            );
+          },
         );
       case AppScreen.wordList:
         return WordListTabContent(


### PR DESCRIPTION
## Summary
- update app bar title for home screen
- show `WordListTabContent` when Home is selected

## Testing
- `dart format --set-exit-if-changed .` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629c07d8fc832abeff5ebba71eab3b