### PR TITLE
Add word list link on home screen

### DIFF
--- a/lib/tabs_content/home_tab_content.dart
+++ b/lib/tabs_content/home_tab_content.dart
@@ -20,6 +20,10 @@ class _HomeTabContentState extends State<HomeTabContent> {
   late Box<HistoryEntry> _historyBox;
   late Box<QuizStat> _quizStatsBox;
 
+  void _openWordList() {
+    widget.navigateTo(AppScreen.wordList);
+  }
+
   Future<void> _openWordbook() async {
     final list = await FlashcardRepository.loadAll();
     if (!mounted) return;
@@ -169,6 +173,11 @@ class _HomeTabContentState extends State<HomeTabContent> {
                     quizStats: quizStats,
                     weekAcc: weekAcc,
                     monthAcc: monthAcc,
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: _openWordList,
+                    child: const Text('単語一覧へ'),
                   ),
                   const SizedBox(height: 8),
                   ElevatedButton(


### PR DESCRIPTION
## Why
Users requested a way to access the word list from the home screen.

## What
- Added `_openWordList()` method.
- Added button on home tab to navigate to the word list screen.

## How
- Updated `HomeTabContent` to include new button.

## Checklist
- [ ] Code formatted


------
https://chatgpt.com/codex/tasks/task_e_686318d35620832ab7643cfd144703f2