### PR TITLE
Update wordbook appbar

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -73,14 +73,18 @@ class _WordbookScreenState extends State<WordbookScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        titleSpacing: 0,
-        title: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        centerTitle: true,
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
             const Text('単語帳'),
+            const SizedBox(width: 8),
             Text(
-              '現在 ${_currentIndex + 1} / 全 ${widget.flashcards.length}',
-              style: Theme.of(context).textTheme.labelMedium,
+              '(${_currentIndex + 1} / ${widget.flashcards.length})',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(fontWeight: FontWeight.bold),
             ),
           ],
         ),

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tango/flashcard_model.dart';
+import 'package:tango/wordbook_screen.dart';
+
+Flashcard _card(int i) => Flashcard(
+      id: '$i',
+      term: 't$i',
+      reading: 't$i',
+      description: 'd',
+      categoryLarge: 'A',
+      categoryMedium: 'B',
+      categorySmall: 'C',
+      categoryItem: 'D',
+      importance: 1,
+      lastReviewed: null,
+      nextDue: null,
+      wrongCount: 0,
+      correctCount: 0,
+    );
+
+void main() {
+  testWidgets('shows current page indicator in AppBar', (tester) async {
+    final cards = List.generate(861, (i) => _card(i + 1));
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 77});
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+        home: WordbookScreen(
+      flashcards: cards,
+      prefsProvider: () async => prefs,
+    )));
+    await tester.pumpAndSettle();
+    expect(find.text('(78 / 861)'), findsOneWidget);
+  });
+}

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -32,7 +32,7 @@ void main() {
       prefsProvider: () async => prefs,
     )));
     await tester.pumpAndSettle();
-    expect(find.text('現在 2 / 全 2'), findsOneWidget);
+    expect(find.text('(2 / 2)'), findsOneWidget);
   });
 
   testWidgets('saves bookmark on page change', (tester) async {
@@ -68,7 +68,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // PageView moved to selected index
-    expect(find.text('現在 2 / 全 2'), findsOneWidget);
+    expect(find.text('(2 / 2)'), findsOneWidget);
 
     // Bookmark saved
     expect(prefs.getInt('bookmark_pageIndex'), 1);


### PR DESCRIPTION
## Why
- follow slim UI spec for wordbook screen

## What
- center app bar title with current/total pages
- adjust existing tests and add dedicated app bar test

## How
- dart format *(fails: `dart` not found)*
- flutter analyze *(fails: `flutter` not found)*
- flutter test *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863387a2570832aa13988f2e71e0346