### PR TITLE
Fix wordbook header duplication

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -37,6 +37,9 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   final WordDetailController _detailController = WordDetailController();
   final GlobalKey<WordListTabContentState> _wordListKey =
       GlobalKey<WordListTabContentState>();
+  final GlobalKey<WordbookScreenState> _wordbookKey =
+      GlobalKey<WordbookScreenState>();
+  int _wordbookIndex = 0;
   ReviewMode _reviewMode = ReviewMode.random;
 
   String _getAppBarTitle() {
@@ -118,7 +121,13 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         if (_currentArguments?.flashcards != null) {
           final list = _currentArguments!.flashcards!;
           return WordbookScreen(
+            key: _wordbookKey,
             flashcards: list,
+            onIndexChanged: (i) {
+              setState(() {
+                _wordbookIndex = i;
+              });
+            },
           );
         }
         return const Center(child: CircularProgressIndicator());
@@ -302,6 +311,10 @@ class _MainScreenState extends ConsumerState<MainScreen> {
             if (_currentScreen == AppScreen.wordList && words != null) {
               return Text(
                   '$baseTitle (${filtered.length} / ${words.length} 件)');
+            } else if (_currentScreen == AppScreen.wordbook &&
+                _currentArguments?.flashcards != null) {
+              final total = _currentArguments!.flashcards!.length;
+              return Text('$baseTitle (${_wordbookIndex + 1} / $total)');
             }
             return Text(baseTitle);
           },
@@ -368,6 +381,13 @@ class _MainScreenState extends ConsumerState<MainScreen> {
             OverflowMenu(
               onOpenSheet: () {
                 _wordListKey.currentState?.openFilterSheet(context);
+              },
+            ),
+          if (_currentScreen == AppScreen.wordbook)
+            IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: () {
+                _wordbookKey.currentState?.openSearch();
               },
             ),
           if (_currentScreen != AppScreen.settings)

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -7,20 +7,28 @@ import 'word_detail_content.dart';
 class WordbookScreen extends StatefulWidget {
   final List<Flashcard> flashcards;
   final Future<SharedPreferences> Function() prefsProvider;
+  final ValueChanged<int>? onIndexChanged;
+
   const WordbookScreen({
     Key? key,
     required this.flashcards,
     this.prefsProvider = SharedPreferences.getInstance,
+    this.onIndexChanged,
   }) : super(key: key);
 
   @override
-  State<WordbookScreen> createState() => _WordbookScreenState();
+  State<WordbookScreen> createState() => WordbookScreenState();
 }
 
-class _WordbookScreenState extends State<WordbookScreen> {
+class WordbookScreenState extends State<WordbookScreen> {
   static const _bookmarkKey = 'bookmark_pageIndex';
   late PageController _pageController;
   int _currentIndex = 0;
+
+  int get currentIndex => _currentIndex;
+  List<Flashcard> get flashcards => widget.flashcards;
+
+  Future<void> openSearch() => _openSearch();
 
   @override
   void initState() {
@@ -37,6 +45,7 @@ class _WordbookScreenState extends State<WordbookScreen> {
     setState(() {
       _currentIndex = index;
     });
+    widget.onIndexChanged?.call(index);
   }
 
   Future<void> _saveBookmark(int index) async {
@@ -60,6 +69,7 @@ class _WordbookScreenState extends State<WordbookScreen> {
         _currentIndex = result;
       });
       _saveBookmark(result);
+      widget.onIndexChanged?.call(result);
     }
   }
 
@@ -71,46 +81,22 @@ class _WordbookScreenState extends State<WordbookScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text('単語帳'),
-            const SizedBox(width: 8),
-            Text(
-              '(${_currentIndex + 1} / ${widget.flashcards.length})',
-              style: Theme.of(context)
-                  .textTheme
-                  .titleMedium
-                  ?.copyWith(fontWeight: FontWeight.bold),
-            ),
-          ],
-        ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.search),
-            onPressed: _openSearch,
-          ),
-        ],
-      ),
-      body: PageView.builder(
-        controller: _pageController,
-        itemCount: widget.flashcards.length,
-        onPageChanged: (index) {
-          setState(() {
-            _currentIndex = index;
-          });
-          _saveBookmark(index);
-        },
-        itemBuilder: (context, index) {
-          return WordDetailContent(
-            flashcards: [widget.flashcards[index]],
-            initialIndex: 0,
-          );
-        },
-      ),
+    return PageView.builder(
+      controller: _pageController,
+      itemCount: widget.flashcards.length,
+      onPageChanged: (index) {
+        setState(() {
+          _currentIndex = index;
+        });
+        _saveBookmark(index);
+        widget.onIndexChanged?.call(index);
+      },
+      itemBuilder: (context, index) {
+        return WordDetailContent(
+          flashcards: [widget.flashcards[index]],
+          initialIndex: 0,
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Why
Wordbook screen used its own Scaffold, which resulted in two app bars being visible when the tab was opened. This obscured the vocabulary content.

## What
- Removed internal AppBar from `WordbookScreen`
- Exposed search and page index via `WordbookScreenState`
- Updated `MainScreen` to host wordbook title and search action in the main AppBar

## How
- `WordbookScreen` now returns only a `PageView` and notifies index changes to the parent.
- `MainScreen` listens for these updates and displays `単語帳 (page/total)` with a search button when the wordbook tab is active.

- [ ] Code format check *(failed: `dart` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686350c3daa0832a86a20e479de9b305