### PR TITLE
Remove footer navigation from WordbookScreen

### DIFF
--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -20,12 +20,14 @@ class WordDetailContent extends StatefulWidget {
   final List<Flashcard> flashcards;
   final int initialIndex;
   final WordDetailController? controller;
+  final bool showNavigation;
 
   const WordDetailContent({
     Key? key,
     required this.flashcards,
     required this.initialIndex,
     this.controller,
+    this.showNavigation = true,
   }) : super(key: key);
 
   @override
@@ -486,35 +488,36 @@ class _WordDetailContentState extends State<WordDetailContent> {
             },
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              TextButton(
-                onPressed: _currentIndex > 0
-                    ? () {
-                        _pageController.previousPage(
-                            duration: const Duration(milliseconds: 300),
-                            curve: Curves.easeInOut);
-                      }
-                    : null,
-                child: const Text('前へ'),
-              ),
-              Text('${_currentIndex + 1} / ${_displayFlashcards.length}'),
-              TextButton(
-                onPressed: _currentIndex < _displayFlashcards.length - 1
-                    ? () {
-                        _pageController.nextPage(
-                            duration: const Duration(milliseconds: 300),
-                            curve: Curves.easeInOut);
-                      }
-                    : null,
-                child: const Text('次へ'),
-              ),
-            ],
+        if (widget.showNavigation && _displayFlashcards.length > 1)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton(
+                  onPressed: _currentIndex > 0
+                      ? () {
+                          _pageController.previousPage(
+                              duration: const Duration(milliseconds: 300),
+                              curve: Curves.easeInOut);
+                        }
+                      : null,
+                  child: const Text('前へ'),
+                ),
+                Text('${_currentIndex + 1} / ${_displayFlashcards.length}'),
+                TextButton(
+                  onPressed: _currentIndex < _displayFlashcards.length - 1
+                      ? () {
+                          _pageController.nextPage(
+                              duration: const Duration(milliseconds: 300),
+                              curve: Curves.easeInOut);
+                        }
+                      : null,
+                  child: const Text('次へ'),
+                ),
+              ],
+            ),
           ),
-        ),
       ],
     );
   }

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -95,6 +95,7 @@ class WordbookScreenState extends State<WordbookScreen> {
         return WordDetailContent(
           flashcards: [widget.flashcards[index]],
           initialIndex: 0,
+          showNavigation: false,
         );
       },
     );


### PR DESCRIPTION
## Why
The footer with "次へ" and "前へ" buttons is unnecessary on the Wordbook screen because each page only shows one flashcard.

## What
- Added `showNavigation` option to `WordDetailContent`
- Disabled navigation footer when used by `WordbookScreen`

## How
- Updated widget constructor and conditional rendering

- [ ] Code formatted


------
https://chatgpt.com/codex/tasks/task_e_686357988e5c832a9811204c58c53f2d