### PR TITLE
feat: add desktop nav arrows

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -81,23 +81,79 @@ class WordbookScreenState extends State<WordbookScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return PageView.builder(
-      controller: _pageController,
-      itemCount: widget.flashcards.length,
-      onPageChanged: (index) {
-        setState(() {
-          _currentIndex = index;
-        });
-        _saveBookmark(index);
-        widget.onIndexChanged?.call(index);
-      },
-      itemBuilder: (context, index) {
-        return WordDetailContent(
-          flashcards: [widget.flashcards[index]],
-          initialIndex: 0,
-          showNavigation: false,
-        );
-      },
+    final isWide = MediaQuery.of(context).size.width > 600;
+    return Stack(
+      children: [
+        PageView.builder(
+          controller: _pageController,
+          itemCount: widget.flashcards.length,
+          onPageChanged: (index) {
+            setState(() {
+              _currentIndex = index;
+            });
+            _saveBookmark(index);
+            widget.onIndexChanged?.call(index);
+          },
+          itemBuilder: (context, index) {
+            return WordDetailContent(
+              flashcards: [widget.flashcards[index]],
+              initialIndex: 0,
+              showNavigation: false,
+            );
+          },
+        ),
+        if (isWide && widget.flashcards.length > 1)
+          Positioned.fill(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                _NavButton(
+                  icon: Icons.chevron_left,
+                  onTap: _currentIndex > 0
+                      ? () {
+                          _pageController.previousPage(
+                            duration: const Duration(milliseconds: 300),
+                            curve: Curves.easeInOut,
+                          );
+                        }
+                      : null,
+                ),
+                _NavButton(
+                  icon: Icons.chevron_right,
+                  onTap: _currentIndex < widget.flashcards.length - 1
+                      ? () {
+                          _pageController.nextPage(
+                            duration: const Duration(milliseconds: 300),
+                            curve: Curves.easeInOut,
+                          );
+                        }
+                      : null,
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _NavButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  const _NavButton({required this.icon, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: Opacity(
+        opacity: 0.6,
+        child: IconButton(
+          icon: Icon(icon, size: 36),
+          onPressed: onTap,
+        ),
+      ),
     );
   }
 }

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -73,4 +73,38 @@ void main() {
     // Bookmark saved
     expect(prefs.getInt('bookmark_pageIndex'), 1);
   });
+
+  testWidgets('shows nav arrows on wide screen', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(size: Size(800, 600)),
+      child: MaterialApp(
+        home: WordbookScreen(
+          flashcards: cards,
+          prefsProvider: () async => prefs,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+  });
+
+  testWidgets('hides nav arrows on narrow screen', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(size: Size(320, 600)),
+      child: MaterialApp(
+        home: WordbookScreen(
+          flashcards: cards,
+          prefsProvider: () async => prefs,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.chevron_left), findsNothing);
+    expect(find.byIcon(Icons.chevron_right), findsNothing);
+  });
 }


### PR DESCRIPTION
## Why
- browsing words on desktop lacked obvious navigation

## What
- overlay chevron buttons on WordbookScreen for wide layouts
- added tests verifying buttons appear or not depending on width

## How
- stacked nav buttons over PageView and created `_NavButton` widget
- updated widget tests

- [ ] `dart format` (fails: `dart: command not found`)
- [ ] `flutter test` (not run: missing flutter)


------
https://chatgpt.com/codex/tasks/task_e_68635a979494832ab953362cdbb5e055