### PR TITLE
Add nav buttons for mobile

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -81,7 +81,6 @@ class WordbookScreenState extends State<WordbookScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final isWide = MediaQuery.of(context).size.width > 600;
     return Stack(
       children: [
         PageView.builder(
@@ -102,7 +101,7 @@ class WordbookScreenState extends State<WordbookScreen> {
             );
           },
         ),
-        if (isWide && widget.flashcards.length > 1)
+        if (widget.flashcards.length > 1)
           Positioned.fill(
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -91,7 +91,7 @@ void main() {
     expect(find.byIcon(Icons.chevron_right), findsOneWidget);
   });
 
-  testWidgets('hides nav arrows on narrow screen', (tester) async {
+  testWidgets('shows nav arrows on narrow screen', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
     final prefs = await SharedPreferences.getInstance();
     await tester.pumpWidget(MediaQuery(
@@ -104,7 +104,7 @@ void main() {
       ),
     ));
     await tester.pumpAndSettle();
-    expect(find.byIcon(Icons.chevron_left), findsNothing);
-    expect(find.byIcon(Icons.chevron_right), findsNothing);
+    expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Why
The wordbook screen only displayed navigation arrows on wide layouts, but users wanted to try them on phones as well.

## What
- display left/right nav buttons regardless of screen width
- update tests for new behavior

## How
- removed width check in `WordbookScreen`
- updated widget test expectations

No other files changed.


------
https://chatgpt.com/codex/tasks/task_e_68635dbe2a50832aafe2e57803a2198d