### PR TITLE
Refactor main screen helpers

### DIFF
--- a/lib/navigation_helper.dart
+++ b/lib/navigation_helper.dart
@@ -1,0 +1,43 @@
+import 'app_view.dart';
+
+AppScreen appScreenFromIndex(int index) {
+  switch (index) {
+    case 0:
+      return AppScreen.home;
+    case 1:
+      return AppScreen.wordList;
+    case 2:
+      return AppScreen.wordbook;
+    case 3:
+      return AppScreen.history;
+    case 4:
+      return AppScreen.quiz;
+    default:
+      return AppScreen.home;
+  }
+}
+
+int indexFromAppScreen(AppScreen screen, int currentIndex) {
+  switch (screen) {
+    case AppScreen.home:
+      return 0;
+    case AppScreen.wordList:
+      return 1;
+    case AppScreen.favorites:
+      return 2;
+    case AppScreen.history:
+      return 3;
+    case AppScreen.quiz:
+      return 4;
+    case AppScreen.wordDetail:
+      return 1;
+    case AppScreen.wordbook:
+      return 2;
+    case AppScreen.todaySummary:
+    case AppScreen.learningHistoryDetail:
+    case AppScreen.about:
+      return 0;
+    case AppScreen.settings:
+      return currentIndex;
+  }
+}

--- a/lib/utils/main_screen_utils.dart
+++ b/lib/utils/main_screen_utils.dart
@@ -1,0 +1,44 @@
+import '../app_view.dart';
+import '../word_detail_controller.dart';
+
+String getAppBarTitle(
+  AppScreen screen,
+  WordDetailController detailController,
+  ScreenArguments? args,
+) {
+  switch (screen) {
+    case AppScreen.home:
+      return 'ホーム';
+    case AppScreen.wordList:
+      return '単語一覧';
+    case AppScreen.wordDetail:
+      final current = detailController.currentFlashcard;
+      if (current != null) {
+        return current.term;
+      }
+      if (args?.flashcards != null && args?.initialIndex != null) {
+        final list = args!.flashcards!;
+        final index = args.initialIndex!;
+        if (index >= 0 && index < list.length) {
+          return list[index].term;
+        }
+      }
+      return '単語詳細';
+    case AppScreen.wordbook:
+      return '単語帳';
+    case AppScreen.favorites:
+      return '準備中';
+    case AppScreen.history:
+      return '閲覧履歴';
+    case AppScreen.quiz:
+      return 'クイズ';
+    case AppScreen.todaySummary:
+      return '今日の学習サマリー';
+    case AppScreen.learningHistoryDetail:
+      return '学習履歴詳細';
+    case AppScreen.about:
+      return 'このアプリについて';
+    case AppScreen.settings:
+      return '設定';
+  }
+}

--- a/lib/widgets/main_bottom_navigation_bar.dart
+++ b/lib/widgets/main_bottom_navigation_bar.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class MainBottomNavigationBar extends StatelessWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+  final Widget Function(IconData, BuildContext, int) activeIconBuilder;
+
+  const MainBottomNavigationBar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+    required this.activeIconBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      items: [
+        BottomNavigationBarItem(
+          icon: const Icon(Icons.home_outlined),
+          activeIcon: activeIconBuilder(Icons.home, context, 0),
+          label: 'ホーム',
+        ),
+        BottomNavigationBarItem(
+          icon: const Icon(Icons.list_alt_outlined),
+          activeIcon: activeIconBuilder(Icons.list_alt, context, 1),
+          label: '単語一覧',
+        ),
+        BottomNavigationBarItem(
+          icon: const Icon(Icons.menu_book_outlined),
+          activeIcon: activeIconBuilder(Icons.menu_book, context, 2),
+          label: '単語帳',
+        ),
+        BottomNavigationBarItem(
+          icon: const Icon(Icons.history_outlined),
+          activeIcon: activeIconBuilder(Icons.history, context, 3),
+          label: '履歴',
+        ),
+        BottomNavigationBarItem(
+          icon: const Icon(Icons.quiz_outlined),
+          activeIcon: activeIconBuilder(Icons.quiz, context, 4),
+          label: 'クイズ',
+        ),
+      ],
+      currentIndex: currentIndex,
+      onTap: onTap,
+      type: BottomNavigationBarType.fixed,
+      showUnselectedLabels: true,
+    );
+  }
+}


### PR DESCRIPTION
## Why
- `lib/main_screen.dart` was over 400 lines with navigation mapping and widget building logic inside

## What
- moved navigation mapping functions to `navigation_helper.dart`
- extracted app bar title logic to `utils/main_screen_utils.dart`
- created `MainBottomNavigationBar` widget
- updated `MainScreen` to use the new helpers

## How
- no tests are provided in this environment

------
https://chatgpt.com/codex/tasks/task_e_68639bff03cc832a9110e0a5a87bd90a