### PR TITLE
Fix bookmark index overflow in WordbookScreen

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -39,7 +39,8 @@ class WordbookScreenState extends State<WordbookScreen> {
 
   Future<void> _loadBookmark() async {
     final prefs = await widget.prefsProvider();
-    final index = prefs.getInt(_bookmarkKey) ?? 0;
+    int index = prefs.getInt(_bookmarkKey) ?? 0;
+    index = index.clamp(0, widget.flashcards.length - 1);
     if (!mounted) return;
     _pageController.jumpToPage(index);
     setState(() {


### PR DESCRIPTION
## Why
The saved bookmark index could exceed the number of flashcards. This caused `_currentIndex` to become inconsistent with the page controller, preventing the first word from appearing correctly.

## What
- clamp the loaded bookmark index within the valid page range

## How
- updated `_loadBookmark()` in `wordbook_screen.dart`

- [ ] `dart format` *(failed: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a139f604832abe2eb85d802e3135