### PR TITLE
feat: hide wordbook arrows on mobile

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -5,3 +5,6 @@ const String flashcardStateBoxName = 'flashcard_state_box';
 const String sessionLogBoxName = 'session_log_box_v1';
 const String reviewQueueBoxName = 'review_queue_box_v1';
 const String settingsBoxName = 'settings_box';
+
+// 端末サイズ判定用のブレークポイント (単位: dp)
+const double kTabletBreakpoint = 600.0;

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'flashcard_model.dart';
 import 'word_detail_content.dart';
+import 'constants.dart';
 
 class WordbookScreen extends StatefulWidget {
   final List<Flashcard> flashcards;
@@ -82,6 +83,8 @@ class WordbookScreenState extends State<WordbookScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final isTabletOrDesktop =
+        MediaQuery.of(context).size.shortestSide >= kTabletBreakpoint;
     return Stack(
       children: [
         PageView.builder(
@@ -102,7 +105,7 @@ class WordbookScreenState extends State<WordbookScreen> {
             );
           },
         ),
-        if (widget.flashcards.length > 1)
+        if (isTabletOrDesktop && widget.flashcards.length > 1)
           Positioned.fill(
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,


### PR DESCRIPTION
## Why
Mobile view shows arrow buttons for navigating flashcards, which should be hidden on phones.

## What
- add a tablet breakpoint constant
- show navigation arrows only on screens wider than the breakpoint

## How
- introduced `kTabletBreakpoint` in `constants.dart`
- checked screen size in `WordbookScreen` before displaying nav arrows

- [ ] Code formatted


------
https://chatgpt.com/codex/tasks/task_e_6863c51e99fc832aa08fb13678a3db6a