### PR TITLE
Fix word order in wordbook screen

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -92,6 +92,7 @@ class FlashcardRepository {
     }
     await _ensureRepos();
     final words = _wordRepo!.list();
+    words.sort((a, b) => a.id.compareTo(b.id));
     final stats = {for (var s in _learningRepo!.all()) s.wordId: s};
     _cache = words.map((w) {
       final stat = stats[w.id];


### PR DESCRIPTION
## Why
The first word was not always displayed correctly on the wordbook screen because the flashcards were returned in an arbitrary order from the repository.

## What
- sort words by id when loading from `FlashcardRepository`

## How
- update repository logic to sort

- [ ] code formatted
- [ ] tests run


------
https://chatgpt.com/codex/tasks/task_e_6863c65a97c4832a9e66387e767e8084