### PR TITLE
Refactor: unify state management with Riverpod

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter/foundation.dart';
-import 'package:provider/provider.dart' as provider_pkg;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'main_screen.dart';
 import 'history_entry_model.dart';
@@ -93,15 +92,13 @@ Future<void> main() async {
   await _openBoxWithMigration<ReviewQueue>(reviewQueueBoxName, cipher);
   await _openBoxWithMigration<SavedThemeMode>(settingsBoxName, cipher);
 
-  final themeProvider = ThemeProvider();
-  await themeProvider.loadAppPreferences();
+  final theme = ThemeProvider();
+  await theme.loadAppPreferences();
 
   runApp(
     ProviderScope(
-      child: provider_pkg.ChangeNotifierProvider(
-        create: (_) => themeProvider,
-        child: const MyApp(),
-      ),
+      overrides: [themeProvider.overrideWithValue(theme)],
+      child: const MyApp(),
     ),
   );
 }
@@ -112,8 +109,8 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final themeProvider = provider_pkg.Provider.of<ThemeProvider>(context);
-    final scale = themeProvider.textScaleFactor;
+    final themeNotifier = ref.watch(themeProvider);
+    final scale = themeNotifier.textScaleFactor;
     final mode = ref.watch(themeModeProvider);
     return MaterialApp(
       title: 'IT資格学習 単語帳',

--- a/lib/tabs_content/settings_tab_content.dart
+++ b/lib/tabs_content/settings_tab_content.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:provider/provider.dart' as provider_pkg;
 import '../theme_provider.dart';
 import '../theme_mode_provider.dart';
 
@@ -44,11 +43,11 @@ class _SettingsTabContentState extends ConsumerState<SettingsTabContent> {
 
   @override
   Widget build(BuildContext context) {
-    final themeProvider = provider_pkg.Provider.of<ThemeProvider>(context);
+    final theme = ref.watch(themeProvider);
     final mode = ref.watch(themeModeProvider);
     final notifier = ref.read(themeModeProvider.notifier);
     // 現在の文字サイズを ThemeProvider から取得
-    AppFontSize currentAppFontSize = themeProvider.appFontSize;
+    AppFontSize currentAppFontSize = theme.appFontSize;
 
     return ListView(
       padding: const EdgeInsets.all(16.0),
@@ -171,9 +170,7 @@ class _SettingsTabContentState extends ConsumerState<SettingsTabContent> {
                   child: Text('適用'),
                   onPressed: () {
                     // ★★★ ThemeProvider の setAppFontSize を呼び出す ★★★
-                    provider_pkg.Provider.of<ThemeProvider>(context,
-                            listen: false)
-                        .setAppFontSize(selectedFontSizeEnum);
+                    ref.read(themeProvider).setAppFontSize(selectedFontSizeEnum);
                     Navigator.of(dialogContext).pop();
                   },
                 ),

--- a/lib/theme_provider.dart
+++ b/lib/theme_provider.dart
@@ -1,6 +1,7 @@
 // lib/theme_provider.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum AppFontSize { small, medium, large }
@@ -99,3 +100,7 @@ class ThemeProvider with ChangeNotifier {
     }
   }
 }
+
+final themeProvider = ChangeNotifierProvider<ThemeProvider>((ref) {
+  return ThemeProvider();
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -538,14 +538,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  provider:
-    dependency: "direct main"
-    description:
-      name: provider
-      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,6 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  provider: ^6.0.0 # または最新バージョン (pub.devで確認)
   shared_preferences: ^2.0.15 # または最新バージョン
 
   # ここに Hive 関連のパッケージを移動・修正しました


### PR DESCRIPTION
## Why
- `main.dart` mixed Provider and Riverpod making state handling harder
- unify on Riverpod to keep state management consistent

## What
- removed provider package usage
- added a Riverpod `ChangeNotifierProvider` for `ThemeProvider`
- updated `main.dart` and settings screen to use the new provider
- cleaned up dependencies

## How
- manual refactor, could not run `dart format` or `pub get` because Dart/Flutter were unavailable


------
https://chatgpt.com/codex/tasks/task_e_6863c82c1864832a9a2536a713eec147