### PR TITLE
Use typed Hive model for flashcard state

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'models/learning_stat.dart';
 import 'models/quiz_stat.dart';
 import 'models/session_log.dart';
 import 'models/review_queue.dart';
+import 'models/flashcard_state.dart';
 import 'constants.dart';
 import 'services/word_repository.dart';
 import 'services/learning_repository.dart';
@@ -78,6 +79,9 @@ Future<void> main() async {
   if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
     Hive.registerAdapter(SavedThemeModeAdapter());
   }
+  if (!Hive.isAdapterRegistered(FlashcardStateAdapter().typeId)) {
+    Hive.registerAdapter(FlashcardStateAdapter());
+  }
 
   final key = await _getEncryptionKey();
   final cipher = HiveAesCipher(key);
@@ -85,7 +89,7 @@ Future<void> main() async {
   await _openBoxWithMigration<Map>(favoritesBoxName, cipher);
   await _openBoxWithMigration<HistoryEntry>(historyBoxName, cipher);
   await _openBoxWithMigration<QuizStat>(quizStatsBoxName, cipher);
-  await _openBoxWithMigration<Map>(flashcardStateBoxName, cipher);
+  await _openBoxWithMigration<FlashcardState>(flashcardStateBoxName, cipher);
   await _openBoxWithMigration<Word>(WordRepository.boxName, cipher);
   await _openBoxWithMigration<LearningStat>(LearningRepository.boxName, cipher);
   await _openBoxWithMigration<SessionLog>(sessionLogBoxName, cipher);

--- a/lib/models/flashcard_state.dart
+++ b/lib/models/flashcard_state.dart
@@ -1,0 +1,72 @@
+import 'package:hive/hive.dart';
+import '../tag_stats.dart';
+
+class FlashcardState {
+  final DateTime? lastReviewed;
+  final DateTime? nextDue;
+  final int wrongCount;
+  final int correctCount;
+  final Map<String, TagStats> tagStats;
+
+  FlashcardState({
+    this.lastReviewed,
+    this.nextDue,
+    this.wrongCount = 0,
+    this.correctCount = 0,
+    Map<String, TagStats>? tagStats,
+  }) : tagStats = tagStats ?? {};
+
+  FlashcardState copyWith({
+    DateTime? lastReviewed,
+    DateTime? nextDue,
+    int? wrongCount,
+    int? correctCount,
+    Map<String, TagStats>? tagStats,
+  }) {
+    return FlashcardState(
+      lastReviewed: lastReviewed ?? this.lastReviewed,
+      nextDue: nextDue ?? this.nextDue,
+      wrongCount: wrongCount ?? this.wrongCount,
+      correctCount: correctCount ?? this.correctCount,
+      tagStats: tagStats ?? Map<String, TagStats>.from(this.tagStats),
+    );
+  }
+}
+
+class FlashcardStateAdapter extends TypeAdapter<FlashcardState> {
+  @override
+  final int typeId = 8;
+
+  @override
+  FlashcardState read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return FlashcardState(
+      lastReviewed: fields[0] as DateTime?,
+      nextDue: fields[1] as DateTime?,
+      wrongCount: fields[2] as int,
+      correctCount: fields[3] as int,
+      tagStats: (fields[4] as Map?)?.map((k, v) =>
+              MapEntry(k as String, TagStats.fromMap(v as Map))) ??
+          {},
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, FlashcardState obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.lastReviewed)
+      ..writeByte(1)
+      ..write(obj.nextDue)
+      ..writeByte(2)
+      ..write(obj.wrongCount)
+      ..writeByte(3)
+      ..write(obj.correctCount)
+      ..writeByte(4)
+      ..write(obj.tagStats.map((k, v) => MapEntry(k, v.toMap())));
+  }
+}


### PR DESCRIPTION
## Why
Box<Map> was used for storing flashcard review state, leading to many cast operations.

## What
- introduce `FlashcardState` model with `TypeAdapter`
- register adapter and open new box in `main.dart`
- update `ReviewService` and quiz result logic to use `Box<FlashcardState>`

## How
- manual TypeAdapter to avoid build_runner
- migrated state access and write code

No tests were run because flutter tooling is unavailable.

------
https://chatgpt.com/codex/tasks/task_e_6863cb52cca0832a9c81941e41c9fcf4