### PR TITLE
Refactor FlashcardRepository for DI

### DIFF
--- a/lib/flashcard_repository_provider.dart
+++ b/lib/flashcard_repository_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'flashcard_repository.dart';
+
+final flashcardRepositoryProvider = Provider<FlashcardRepository>((ref) {
+  throw UnimplementedError();
+});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,8 @@ import 'theme_provider.dart';
 import 'theme/app_theme.dart';
 import 'theme_mode_provider.dart';
 import 'models/saved_theme_mode.dart';
+import 'flashcard_repository.dart';
+import 'flashcard_repository_provider.dart';
 
 const _secureKeyName = 'hive_encryption_key';
 const _secureStorage = FlutterSecureStorage();
@@ -98,10 +100,14 @@ Future<void> main() async {
 
   final theme = ThemeProvider();
   await theme.loadAppPreferences();
+  final flashcardRepo = await FlashcardRepository.open();
 
   runApp(
     ProviderScope(
-      overrides: [themeProvider.overrideWithValue(theme)],
+      overrides: [
+        themeProvider.overrideWithValue(theme),
+        flashcardRepositoryProvider.overrideWithValue(flashcardRepo),
+      ],
       child: const MyApp(),
     ),
   );

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -23,6 +23,7 @@ import 'wordbook_screen.dart';
 import 'word_list_query.dart';
 import 'overflow_menu.dart';
 import 'flashcard_repository.dart';
+import 'flashcard_repository_provider.dart';
 import 'navigation_helper.dart';
 import 'utils/main_screen_utils.dart';
 import 'widgets/main_bottom_navigation_bar.dart';
@@ -132,7 +133,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       return;
     }
     if (index == 2) {
-      FlashcardRepository.loadAll().then((list) {
+      ref.read(flashcardRepositoryProvider).loadAll().then((list) {
         if (!mounted) return;
         setState(() {
           _bottomNavIndex = index;

--- a/lib/quiz_in_progress_screen.dart
+++ b/lib/quiz_in_progress_screen.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 
 import 'flashcard_model.dart';
 import 'flashcard_repository.dart';
+import 'flashcard_repository_provider.dart';
 import 'quiz_setup_screen.dart';
 import 'quiz_result_screen.dart';
 import 'star_color.dart';
@@ -11,7 +13,7 @@ import 'constants.dart';
 import 'services/learning_repository.dart';
 import 'services/review_queue_service.dart';
 
-class QuizInProgressScreen extends StatefulWidget {
+class QuizInProgressScreen extends ConsumerStatefulWidget {
   final List<Flashcard> quizSessionWords;
   final int totalSessionQuestions;
   final QuizType quizSessionType;
@@ -24,10 +26,10 @@ class QuizInProgressScreen extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<QuizInProgressScreen> createState() => _QuizInProgressScreenState();
+  ConsumerState<QuizInProgressScreen> createState() => _QuizInProgressScreenState();
 }
 
-class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
+class _QuizInProgressScreenState extends ConsumerState<QuizInProgressScreen> {
   late Box<Map> _favoritesBox;
   List<Flashcard>? _allWords;
   int _currentIndex = 0;
@@ -56,7 +58,7 @@ class _QuizInProgressScreenState extends State<QuizInProgressScreen> {
     _queueService = ReviewQueueService();
     _repo();
     _startTime = DateTime.now();
-    FlashcardRepository.loadAll().then((cards) {
+    ref.read(flashcardRepositoryProvider).loadAll().then((cards) {
       if (mounted) setState(() => _allWords = cards);
     });
     _loadQuestion();

--- a/lib/quiz_setup_screen.dart
+++ b/lib/quiz_setup_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'flashcard_model.dart';
 import 'review_service.dart';
+import 'flashcard_repository_provider.dart';
 import 'review_mode_ext.dart';
 import 'quiz_in_progress_screen.dart';
 import 'star_color.dart';
@@ -11,16 +13,17 @@ enum QuizType { multipleChoice, flashcard }
 
 /// Quiz setup screen widget.
 /// Users configure quiz options before starting a session.
-class QuizSetupScreen extends StatefulWidget {
+class QuizSetupScreen extends ConsumerStatefulWidget {
   final ReviewMode mode;
 
   const QuizSetupScreen({Key? key, required this.mode}) : super(key: key);
 
   @override
-  State<QuizSetupScreen> createState() => _QuizSetupScreenState();
+  @override
+  ConsumerState<QuizSetupScreen> createState() => _QuizSetupScreenState();
 }
 
-class _QuizSetupScreenState extends State<QuizSetupScreen> {
+class _QuizSetupScreenState extends ConsumerState<QuizSetupScreen> {
   late ReviewMode _mode;
   QuizType _quizType = QuizType.multipleChoice;
   int _questionCount = 10;
@@ -50,7 +53,7 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
 
   /// Fetch available word count for a review mode.
   Future<int> fetchAvailableWordCount(ReviewMode mode) async {
-    final service = ReviewService();
+    final service = ReviewService(ref.read(flashcardRepositoryProvider));
     final cards = await service.fetchForMode(mode);
     return cards.length;
   }
@@ -84,7 +87,7 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
   }
 
   Future<void> _startQuiz() async {
-    final service = ReviewService();
+    final service = ReviewService(ref.read(flashcardRepositoryProvider));
     final allCards = await service.fetchForMode(_mode);
     if (!mounted) return;
     final sessionWords = allCards.take(_questionCount).toList();

--- a/lib/review_service.dart
+++ b/lib/review_service.dart
@@ -3,6 +3,7 @@ import 'package:hive/hive.dart';
 
 import 'flashcard_model.dart';
 import 'flashcard_repository.dart';
+import 'flashcard_repository_provider.dart';
 import 'tag_stats.dart';
 import 'models/flashcard_state.dart';
 import 'constants.dart';
@@ -22,8 +23,10 @@ enum ReviewMode {
 /// Helper service for computing review priorities and fetching flashcards.
 class ReviewService {
   final Box<FlashcardState> _stateBox;
+  final FlashcardRepository _flashcardRepo;
 
-  ReviewService() : _stateBox = Hive.box<FlashcardState>(flashcardStateBoxName);
+  ReviewService(this._flashcardRepo)
+      : _stateBox = Hive.box<FlashcardState>(flashcardStateBoxName);
 
   /// Merge saved state into a flashcard instance.
   Flashcard mergeState(Flashcard card) {
@@ -106,7 +109,7 @@ class ReviewService {
 
   /// Load all flashcards with state merged in.
   Future<List<Flashcard>> _loadAllWithState() async {
-    final cards = await FlashcardRepository.loadAll();
+    final cards = await _flashcardRepo.loadAll();
     return cards.map(mergeState).toList();
   }
 

--- a/lib/study_start_sheet.dart
+++ b/lib/study_start_sheet.dart
@@ -5,6 +5,7 @@ import 'review_service.dart';
 import 'study_session_controller.dart';
 import 'flashcard_model.dart';
 import 'flashcard_repository.dart';
+import 'flashcard_repository_provider.dart';
 import 'word_detail_content.dart';
 
 class StudyStartSheet extends ConsumerStatefulWidget {
@@ -20,7 +21,7 @@ class _StudyStartSheetState extends ConsumerState<StudyStartSheet> {
   final List<int> _timerOptions = [0, 15, 25, 30];
 
   Future<void> _start() async {
-    final service = ReviewService();
+    final service = ReviewService(ref.read(flashcardRepositoryProvider));
     final all = await service.fetchForMode(ReviewMode.random);
     final words = all.take(_wordCount).toList();
     if (!mounted || words.isEmpty) return;
@@ -111,7 +112,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen> {
   void _loadChoices() async {
     final state = ref.read(studySessionControllerProvider);
     if (state.words.isEmpty) return;
-    final all = await FlashcardRepository.loadAll();
+    final all = await ref.read(flashcardRepositoryProvider).loadAll();
     final word = state.words[state.currentIndex];
     _choices = List<Flashcard>.from(all)
       ..removeWhere((c) => c.id == word.id);

--- a/lib/tabs_content/history_tab_content.dart
+++ b/lib/tabs_content/history_tab_content.dart
@@ -1,15 +1,17 @@
 // lib/tabs_content/history_tab_content.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart'; // 日時フォーマット用 (pubspec.yaml に intl パッケージを追加してください)
 import '../flashcard_model.dart';
 import '../app_view.dart';
 import '../history_entry_model.dart'; // 履歴エントリーモデルをインポート
 import '../flashcard_repository.dart';
+import '../flashcard_repository_provider.dart';
 import '../constants.dart';
 
-class HistoryTabContent extends StatefulWidget {
+class HistoryTabContent extends ConsumerStatefulWidget {
   final Function(AppScreen screen, {ScreenArguments? args}) navigateTo;
 
   const HistoryTabContent({Key? key, required this.navigateTo})
@@ -19,7 +21,7 @@ class HistoryTabContent extends StatefulWidget {
   _HistoryTabContentState createState() => _HistoryTabContentState();
 }
 
-class _HistoryTabContentState extends State<HistoryTabContent> {
+class _HistoryTabContentState extends ConsumerState<HistoryTabContent> {
   late Box<HistoryEntry> _historyBox;
   List<Flashcard> _allFlashcards = []; // 全単語リストを保持
   bool _isInitialLoading = true;
@@ -39,7 +41,8 @@ class _HistoryTabContentState extends State<HistoryTabContent> {
       _initialError = null;
     });
     try {
-      final loadedCards = await FlashcardRepository.loadAll();
+      final loadedCards =
+          await ref.read(flashcardRepositoryProvider).loadAll();
       if (!mounted) return;
       setState(() {
         _allFlashcards = loadedCards;

--- a/lib/tabs_content/home_tab_content.dart
+++ b/lib/tabs_content/home_tab_content.dart
@@ -1,22 +1,24 @@
 // lib/tabs_content/home_tab_content.dart (旧 home_tab_page.dart から修正)
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../history_entry_model.dart';
 import '../app_view.dart'; // AppScreen enum のため
 import '../constants.dart';
 import '../models/quiz_stat.dart';
 import '../flashcard_repository.dart';
+import '../flashcard_repository_provider.dart';
 
-class HomeTabContent extends StatefulWidget {
+class HomeTabContent extends ConsumerStatefulWidget {
   final Function(AppScreen, {ScreenArguments? args}) navigateTo;
 
   const HomeTabContent({Key? key, required this.navigateTo}) : super(key: key);
 
   @override
-  State<HomeTabContent> createState() => _HomeTabContentState();
+  ConsumerState<HomeTabContent> createState() => _HomeTabContentState();
 }
 
-class _HomeTabContentState extends State<HomeTabContent> {
+class _HomeTabContentState extends ConsumerState<HomeTabContent> {
   late Box<HistoryEntry> _historyBox;
   late Box<QuizStat> _quizStatsBox;
 
@@ -25,7 +27,7 @@ class _HomeTabContentState extends State<HomeTabContent> {
   }
 
   Future<void> _openWordbook() async {
-    final list = await FlashcardRepository.loadAll();
+    final list = await ref.read(flashcardRepositoryProvider).loadAll();
     if (!mounted) return;
     widget.navigateTo(
       AppScreen.wordbook,

--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../flashcard_model.dart';
 import '../word_list_query.dart';
 import '../review_service.dart';
+import '../flashcard_repository_provider.dart';
 import '../word_query_sheet.dart';
 import '../star_color.dart';
 
@@ -203,7 +204,7 @@ class WordListTabContentState extends ConsumerState<WordListTabContent> {
   void updateMode(ReviewMode mode) async {
     // Immediately clear the current list while loading new data.
     ref.read(wordListForModeProvider.notifier).state = null;
-    final service = ReviewService();
+    final service = ReviewService(ref.read(flashcardRepositoryProvider));
     final list = await service.fetchForMode(mode);
     if (!mounted) return;
     ref.read(wordListForModeProvider.notifier).state = list;

--- a/lib/today_summary_screen.dart
+++ b/lib/today_summary_screen.dart
@@ -1,25 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 
 import 'flashcard_model.dart';
 import 'flashcard_repository.dart';
+import 'flashcard_repository_provider.dart';
 import 'history_entry_model.dart';
 import 'app_view.dart';
 import 'constants.dart';
 import 'models/quiz_stat.dart';
 
-class TodaySummaryScreen extends StatefulWidget {
+class TodaySummaryScreen extends ConsumerStatefulWidget {
   final Function(AppScreen, {ScreenArguments? args})? navigateTo;
 
   const TodaySummaryScreen({Key? key, this.navigateTo}) : super(key: key);
 
   @override
-  State<TodaySummaryScreen> createState() => _TodaySummaryScreenState();
+  ConsumerState<TodaySummaryScreen> createState() => _TodaySummaryScreenState();
 }
 
-class _TodaySummaryScreenState extends State<TodaySummaryScreen> {
+class _TodaySummaryScreenState extends ConsumerState<TodaySummaryScreen> {
   late Box<HistoryEntry> _historyBox;
   late Box<QuizStat> _quizStatsBox;
   List<Flashcard> _allFlashcards = [];
@@ -38,7 +40,7 @@ class _TodaySummaryScreenState extends State<TodaySummaryScreen> {
 
   Future<void> _loadAllFlashcards() async {
     try {
-      final cards = await FlashcardRepository.loadAll();
+      final cards = await ref.read(flashcardRepositoryProvider).loadAll();
       if (!mounted) return;
       setState(() {
         _allFlashcards = cards;

--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -1,11 +1,13 @@
 // lib/word_detail_content.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart'; // Hiveをインポート
 import 'flashcard_model.dart';
 import '../history_entry_model.dart'; // 閲覧履歴用のモデルをインポート (libフォルダ直下にある想定)
 import '../word_detail_controller.dart';
 import 'flashcard_repository.dart';
+import 'flashcard_repository_provider.dart';
 import '../star_color.dart';
 import '../constants.dart';
 import 'services/history_service.dart';
@@ -16,7 +18,7 @@ class _ViewState {
   const _ViewState(this.list, this.index);
 }
 
-class WordDetailContent extends StatefulWidget {
+class WordDetailContent extends ConsumerStatefulWidget {
   final List<Flashcard> flashcards;
   final int initialIndex;
   final WordDetailController? controller;
@@ -31,10 +33,11 @@ class WordDetailContent extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _WordDetailContentState createState() => _WordDetailContentState();
+  @override
+  ConsumerState<WordDetailContent> createState() => _WordDetailContentState();
 }
 
-class _WordDetailContentState extends State<WordDetailContent> {
+class _WordDetailContentState extends ConsumerState<WordDetailContent> {
   late Box<Map> _favoritesBox;
   final HistoryService _historyService = HistoryService();
 
@@ -69,7 +72,7 @@ class _WordDetailContentState extends State<WordDetailContent> {
     _currentWord = widget.flashcards[widget.initialIndex];
     _pageController = PageController(initialPage: _currentIndex);
 
-    FlashcardRepository.loadAll().then((cards) {
+    ref.read(flashcardRepositoryProvider).loadAll().then((cards) {
       if (!mounted) return;
       setState(() {
         _allFlashcards = cards;

--- a/test/flashcard_repository_test.dart
+++ b/test/flashcard_repository_test.dart
@@ -33,9 +33,9 @@ void main() {
         correctCount: 0,
       ),
     ]);
-    FlashcardRepository.setDataSource(source);
-    final first = await FlashcardRepository.loadAll();
-    final second = await FlashcardRepository.loadAll();
+    final repo = await FlashcardRepository.open(dataSource: source);
+    final first = await repo.loadAll();
+    final second = await repo.loadAll();
     expect(source.calls, 1);
     expect(identical(first, second), isTrue);
   });


### PR DESCRIPTION
## Why
- global static state in `FlashcardRepository` made testing difficult
- dependency injection improves flexibility

## What
- turned `FlashcardRepository` into an instantiable class
- added `flashcardRepositoryProvider` for Riverpod
- updated screens and services to use injected repository
- adjusted unit test for new API

## How
- `dart format` was attempted but `dart` command is unavailable in the environment


------
https://chatgpt.com/codex/tasks/task_e_6863d422fb94832ab3f32dbd61699504