### PR TITLE
Refactor MainScreen widget builders

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -47,81 +47,132 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   ReviewMode _reviewMode = ReviewMode.random;
 
 
+  Widget _buildHomeContent() {
+    return HomeTabContent(
+      key: const ValueKey('HomeTabContent'),
+      navigateTo: _navigateTo,
+    );
+  }
+
+  Widget _buildWordListContent() {
+    return WordListTabContent(
+      key: _wordListKey,
+      onWordTap: (flashcards, index) {
+        _navigateTo(
+          AppScreen.wordDetail,
+          args: ScreenArguments(
+            flashcards: flashcards,
+            initialIndex: index,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildWordDetailContent() {
+    if (_currentArguments?.flashcards != null &&
+        _currentArguments?.initialIndex != null) {
+      final list = _currentArguments!.flashcards!;
+      final index = _currentArguments!.initialIndex!;
+      return WordDetailContent(
+        key: ValueKey('${list[index].id}_$index'),
+        flashcards: list,
+        initialIndex: index,
+        controller: _detailController,
+      );
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _navigateTo(AppScreen.wordList);
+      }
+    });
+    return const Center(
+      child: Text('単語情報がありません。一覧に戻ります...'),
+    );
+  }
+
+  Widget _buildWordbookContent() {
+    if (_currentArguments?.flashcards != null) {
+      final list = _currentArguments!.flashcards!;
+      return WordbookScreen(
+        key: _wordbookKey,
+        flashcards: list,
+        onIndexChanged: (i) {
+          setState(() {
+            _wordbookIndex = i;
+          });
+        },
+      );
+    }
+    return const Center(child: CircularProgressIndicator());
+  }
+
+  Widget _buildFavoritesContent() {
+    return const PlaceholderTabContent(
+      key: ValueKey('PlaceholderTabContent'),
+    );
+  }
+
+  Widget _buildHistoryContent() {
+    return const HistoryScreen(key: ValueKey('HistoryScreen'));
+  }
+
+  Widget _buildQuizContent() {
+    return QuizTabContent(
+      key: const ValueKey('QuizTabContent'),
+      navigateTo: _navigateTo,
+      mode: _reviewMode,
+    );
+  }
+
+  Widget _buildTodaySummaryContent() {
+    return TodaySummaryScreen(
+      key: const ValueKey('TodaySummaryScreen'),
+      navigateTo: _navigateTo,
+    );
+  }
+
+  Widget _buildLearningHistoryDetailContent() {
+    return const LearningHistoryDetailScreen(
+      key: ValueKey('LearningHistoryDetail'),
+    );
+  }
+
+  Widget _buildAboutContent() {
+    return const AboutScreen();
+  }
+
+  Widget _buildSettingsContent() {
+    return const SettingsTabContent(
+      key: ValueKey('SettingsTabContent'),
+    );
+  }
+
+
   Widget _buildCurrentScreenContent() {
     switch (_currentScreen) {
       case AppScreen.home:
-        return HomeTabContent(
-          key: const ValueKey('HomeTabContent'),
-          navigateTo: _navigateTo,
-        );
+        return _buildHomeContent();
       case AppScreen.wordList:
-        return WordListTabContent(
-          key: _wordListKey,
-          onWordTap: (flashcards, index) {
-            _navigateTo(
-              AppScreen.wordDetail,
-              args:
-                  ScreenArguments(flashcards: flashcards, initialIndex: index),
-            );
-          },
-        );
+        return _buildWordListContent();
       case AppScreen.wordDetail:
-        if (_currentArguments?.flashcards != null &&
-            _currentArguments?.initialIndex != null) {
-          final list = _currentArguments!.flashcards!;
-          final index = _currentArguments!.initialIndex!;
-          return WordDetailContent(
-            key: ValueKey('${list[index].id}_$index'),
-            flashcards: list,
-            initialIndex: index,
-            controller: _detailController,
-          );
-        }
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            _navigateTo(AppScreen.wordList);
-          }
-        });
-        return const Center(child: Text("単語情報がありません。一覧に戻ります..."));
+        return _buildWordDetailContent();
       case AppScreen.wordbook:
-        if (_currentArguments?.flashcards != null) {
-          final list = _currentArguments!.flashcards!;
-          return WordbookScreen(
-            key: _wordbookKey,
-            flashcards: list,
-            onIndexChanged: (i) {
-              setState(() {
-                _wordbookIndex = i;
-              });
-            },
-          );
-        }
-        return const Center(child: CircularProgressIndicator());
+        return _buildWordbookContent();
       case AppScreen.favorites:
-        return const PlaceholderTabContent(
-          key: ValueKey("PlaceholderTabContent"),
-        );
+        return _buildFavoritesContent();
       case AppScreen.history:
-        return const HistoryScreen(key: ValueKey('HistoryScreen'));
+        return _buildHistoryContent();
       case AppScreen.quiz:
-        return QuizTabContent(
-          // ★ navigateTo を渡す
-          key: const ValueKey("QuizTabContent"),
-          navigateTo: _navigateTo,
-          mode: _reviewMode,
-        );
+        return _buildQuizContent();
       case AppScreen.todaySummary:
-        return TodaySummaryScreen(
-          key: const ValueKey('TodaySummaryScreen'),
-          navigateTo: _navigateTo,
-        );
+        return _buildTodaySummaryContent();
       case AppScreen.learningHistoryDetail:
-        return const LearningHistoryDetailScreen(
-            key: ValueKey('LearningHistoryDetail'));
+        return _buildLearningHistoryDetailContent();
       case AppScreen.about:
-        return const AboutScreen();
+        return _buildAboutContent();
       case AppScreen.settings:
-        return const SettingsTabContent(key: ValueKey("SettingsTabContent"));
+        return _buildSettingsContent();
     }
   }
 


### PR DESCRIPTION
## Why
- `_buildCurrentScreenContent` was a large switch statement with more than 50 lines
- Splitting widget construction improves readability and makes each part testable

## What
- Added dedicated private builder methods for each `AppScreen`
- Updated the switch statement to delegate to these methods

## How
- No behavioral changes


------
https://chatgpt.com/codex/tasks/task_e_6863dc046b78832ab76e1b460ef3564c