### PR TITLE
Remove unused imports in flashcard repository

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -1,16 +1,11 @@
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
-import 'package:hive/hive.dart';
-
-import 'history_entry_model.dart';
 import 'word_list_query.dart';
 
 import 'flashcard_model.dart';
 import 'services/word_repository.dart';
 import 'services/learning_repository.dart';
-import 'models/word.dart';
-import 'models/learning_stat.dart';
 
 List<Flashcard> _parseFlashcards(List<dynamic> jsonData) {
   final cards = <Flashcard>[];


### PR DESCRIPTION
## Why
Clean up unused dependencies from `flashcard_repository.dart`.

## What
- removed unused imports (Hive, HistoryEntry, Word, LearningStat)

## How
- updated file and ran `dart format` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6863e116ef3c832a828323ee70d4252e