### PR TITLE
Fix Hive adapter and provider override issues

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,7 +60,7 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
 
-  final adapters = [
+  final List<TypeAdapter<dynamic>> adapters = [
     HistoryEntryAdapter(),
     WordAdapter(),
     LearningStatAdapter(),
@@ -101,8 +101,8 @@ Future<void> main() async {
   runApp(
     ProviderScope(
       overrides: [
-        themeProvider.overrideWithValue(theme),
-        flashcardRepositoryProvider.overrideWithValue(flashcardRepo),
+        themeProvider.overrideWith((ref) => theme),
+        flashcardRepositoryProvider.overrideWith((ref) => flashcardRepo),
       ],
       child: const MyApp(),
     ),


### PR DESCRIPTION
## Why
Build failed due to type errors when registering Hive adapters and overriding providers.

## What
- typed Hive adapter list and registration loop
- switched provider overrides to `overrideWith`

## How
- `dart format` couldn't run because the tool is missing


------
https://chatgpt.com/codex/tasks/task_e_6863e6c02b5c832a8781afd31aef0c98