### PR TITLE
fix: recover from word list load failure

### DIFF
--- a/lib/tabs_content/word_list_tab_content.dart
+++ b/lib/tabs_content/word_list_tab_content.dart
@@ -205,8 +205,16 @@ class WordListTabContentState extends ConsumerState<WordListTabContent> {
     // Immediately clear the current list while loading new data.
     ref.read(wordListForModeProvider.notifier).state = null;
     final service = ReviewService(ref.read(flashcardRepositoryProvider));
-    final list = await service.fetchForMode(mode);
-    if (!mounted) return;
-    ref.read(wordListForModeProvider.notifier).state = list;
+    try {
+      final list = await service.fetchForMode(mode);
+      if (!mounted) return;
+      ref.read(wordListForModeProvider.notifier).state = list;
+    } catch (e, st) {
+      // Fetching may fail if Hive boxes are not initialized or assets are missing.
+      debugPrint('Failed to load word list: $e');
+      debugPrintStack(stackTrace: st);
+      if (!mounted) return;
+      ref.read(wordListForModeProvider.notifier).state = [];
+    }
   }
 }


### PR DESCRIPTION
## Why
Loading the word list sometimes threw during initialization, which left the state provider `null`. As a result the progress indicator never disappeared on the list screen.

## What
- wrapped `ReviewService.fetchForMode` in `try`/`catch`
- log and fall back to an empty list on error

## How
- `dart format` *(failed: command not found)*
- `dart test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863eff7b2c0832a9a514a940e40d1b5