### PR TITLE
Refactor flashcard repository

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -1,93 +1,23 @@
-import 'dart:convert';
-import 'package:flutter/services.dart' show rootBundle;
-import 'package:http/http.dart' as http;
 import 'word_list_query.dart';
 
 import 'flashcard_model.dart';
-import 'services/word_repository.dart';
-import 'services/learning_repository.dart';
+import 'services/flashcard_loader.dart';
 
-List<Flashcard> _parseFlashcards(List<dynamic> jsonData) {
-  final cards = <Flashcard>[];
-  for (var item in jsonData) {
-    if (item is Map<String, dynamic> &&
-        item['id'] != null &&
-        item['term'] != null) {
-      try {
-        cards.add(Flashcard.fromJson(item));
-      } catch (_) {}
-    }
-  }
-  return cards;
-}
-
-/// Interface for a flashcard data source.
-abstract class FlashcardDataSource {
-  Future<List<Flashcard>> loadAll();
-}
-
-/// Load flashcards from the bundled JSON file.
-class LocalFlashcardDataSource implements FlashcardDataSource {
-  @override
-  Future<List<Flashcard>> loadAll() async {
-    final jsonString = await rootBundle.loadString('assets/words.json');
-    final List<dynamic> jsonData = json.decode(jsonString) as List<dynamic>;
-    return _parseFlashcards(jsonData);
-  }
-}
-
-/// Load flashcards from a remote HTTP endpoint.
-class RemoteFlashcardDataSource implements FlashcardDataSource {
-  final String url;
-  final http.Client _client;
-
-  RemoteFlashcardDataSource(this.url, {http.Client? client})
-      : _client = client ?? http.Client();
-
-  @override
-  Future<List<Flashcard>> loadAll() async {
-    final response = await _client.get(Uri.parse(url));
-    if (response.statusCode != 200) {
-      throw Exception('Failed to load flashcards');
-    }
-    final List<dynamic> jsonData = json.decode(response.body) as List<dynamic>;
-    return _parseFlashcards(jsonData);
-  }
-}
-
-/// Repository that caches flashcards loaded from a data source.
+/// Repository that caches flashcards loaded from a loader.
 class FlashcardRepository {
-  FlashcardDataSource _dataSource;
+  FlashcardLoader _loader;
   List<Flashcard>? _cache;
-  final WordRepository _wordRepo;
-  final LearningRepository _learningRepo;
 
-  FlashcardRepository({
-    FlashcardDataSource? dataSource,
-    required WordRepository wordRepo,
-    required LearningRepository learningRepo,
-  })  : _dataSource = dataSource ?? LocalFlashcardDataSource(),
-        _wordRepo = wordRepo,
-        _learningRepo = learningRepo;
+  FlashcardRepository({required FlashcardLoader loader}) : _loader = loader;
 
-  static Future<FlashcardRepository> open({
-    FlashcardDataSource? dataSource,
-    WordRepository? wordRepo,
-    LearningRepository? learningRepo,
-  }) async {
-    final wr = wordRepo ?? await WordRepository.open();
-    await wr.seedFromAsset('assets/words.json');
-    final lr = learningRepo ?? await LearningRepository.open();
-    return FlashcardRepository(
-      dataSource: dataSource,
-      wordRepo: wr,
-      learningRepo: lr,
-    );
+  static Future<FlashcardRepository> open({FlashcardLoader? loader}) async {
+    final l = loader ?? await HiveFlashcardLoader.open();
+    return FlashcardRepository(loader: l);
   }
 
-  /// Replace the current data source and clear the cache.
-  void setDataSource(FlashcardDataSource source) {
-    _dataSource = source;
+  /// Replace the current loader and clear the cache.
+  void setLoader(FlashcardLoader loader) {
+    _loader = loader;
     _cache = null;
   }
 
@@ -96,32 +26,7 @@ class FlashcardRepository {
     if (_cache != null) {
       return _cache!;
     }
-    final words = _wordRepo.list();
-    words.sort((a, b) => a.id.compareTo(b.id));
-    final stats = {for (var s in _learningRepo.all()) s.wordId: s};
-    _cache = words.map((w) {
-      final stat = stats[w.id];
-      return Flashcard(
-        id: w.id,
-        term: w.term,
-        english: w.english,
-        reading: w.reading,
-        description: w.description,
-        relatedIds: w.relatedIds,
-        tags: w.tags,
-        examExample: w.examExample,
-        examPoint: w.examPoint,
-        practicalTip: w.practicalTip,
-        categoryLarge: w.categoryLarge,
-        categoryMedium: w.categoryMedium,
-        categorySmall: w.categorySmall,
-        categoryItem: w.categoryItem,
-        importance: w.importance,
-        lastReviewed: stat?.lastReviewed,
-        wrongCount: stat?.wrongCount ?? 0,
-        correctCount: stat?.correctCount ?? 0,
-      );
-    }).toList();
+    _cache = await _loader.loadAll();
     return _cache!;
   }
 

--- a/lib/services/flashcard_loader.dart
+++ b/lib/services/flashcard_loader.dart
@@ -1,0 +1,53 @@
+import '../flashcard_model.dart';
+import 'learning_repository.dart';
+import 'word_repository.dart';
+
+abstract class FlashcardLoader {
+  Future<List<Flashcard>> loadAll();
+}
+
+class HiveFlashcardLoader implements FlashcardLoader {
+  final WordRepository _wordRepo;
+  final LearningRepository _learningRepo;
+
+  HiveFlashcardLoader({required WordRepository wordRepo, required LearningRepository learningRepo})
+      : _wordRepo = wordRepo,
+        _learningRepo = learningRepo;
+
+  static Future<HiveFlashcardLoader> open({WordRepository? wordRepo, LearningRepository? learningRepo}) async {
+    final wr = wordRepo ?? await WordRepository.open();
+    await wr.seedFromAsset('assets/words.json');
+    final lr = learningRepo ?? await LearningRepository.open();
+    return HiveFlashcardLoader(wordRepo: wr, learningRepo: lr);
+  }
+
+  @override
+  Future<List<Flashcard>> loadAll() async {
+    final words = _wordRepo.list();
+    words.sort((a, b) => a.id.compareTo(b.id));
+    final stats = {for (var s in _learningRepo.all()) s.wordId: s};
+    return words.map((w) {
+      final stat = stats[w.id];
+      return Flashcard(
+        id: w.id,
+        term: w.term,
+        english: w.english,
+        reading: w.reading,
+        description: w.description,
+        relatedIds: w.relatedIds,
+        tags: w.tags,
+        examExample: w.examExample,
+        examPoint: w.examPoint,
+        practicalTip: w.practicalTip,
+        categoryLarge: w.categoryLarge,
+        categoryMedium: w.categoryMedium,
+        categorySmall: w.categorySmall,
+        categoryItem: w.categoryItem,
+        importance: w.importance,
+        lastReviewed: stat?.lastReviewed,
+        wrongCount: stat?.wrongCount ?? 0,
+        correctCount: stat?.correctCount ?? 0,
+      );
+    }).toList();
+  }
+}

--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tango/models/word.dart';
+import 'package:tango/models/learning_stat.dart';
+import 'package:tango/services/word_repository.dart';
+import 'package:tango/services/learning_repository.dart';
+import 'package:tango/services/flashcard_loader.dart';
+
+void main() {
+  late Directory dir;
+  late WordRepository wordRepo;
+  late LearningRepository learningRepo;
+  late HiveFlashcardLoader loader;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(WordAdapter());
+    Hive.registerAdapter(LearningStatAdapter());
+    wordRepo = await WordRepository.open();
+    learningRepo = await LearningRepository.open();
+    loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk(WordRepository.boxName);
+    await Hive.deleteBoxFromDisk(LearningRepository.boxName);
+    await dir.delete(recursive: true);
+  });
+
+  test('loads flashcards with stats merged', () async {
+    await wordRepo.add(Word(
+      id: '1',
+      term: 'a',
+      reading: 'a',
+      description: 'd',
+      categoryLarge: 'A',
+      categoryMedium: 'B',
+      categorySmall: 'C',
+      categoryItem: 'D',
+      importance: 1,
+    ));
+    await learningRepo.incrementWrong('1');
+
+    final cards = await loader.loadAll();
+    expect(cards.length, 1);
+    expect(cards.first.wrongCount, 1);
+  });
+}

--- a/test/flashcard_repository_test.dart
+++ b/test/flashcard_repository_test.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/flashcard_repository.dart';
+import 'package:tango/services/flashcard_loader.dart';
 
-class _FakeSource implements FlashcardDataSource {
+class _FakeLoader implements FlashcardLoader {
   int calls = 0;
   final List<Flashcard> cards;
-  _FakeSource(this.cards);
+  _FakeLoader(this.cards);
 
   @override
   Future<List<Flashcard>> loadAll() async {
@@ -16,7 +17,7 @@ class _FakeSource implements FlashcardDataSource {
 
 void main() {
   test('FlashcardRepository caches results', () async {
-    final source = _FakeSource([
+    final loader = _FakeLoader([
       Flashcard(
         id: '1',
         term: 'a',
@@ -33,10 +34,10 @@ void main() {
         correctCount: 0,
       ),
     ]);
-    final repo = await FlashcardRepository.open(dataSource: source);
+    final repo = await FlashcardRepository.open(loader: loader);
     final first = await repo.loadAll();
     final second = await repo.loadAll();
-    expect(source.calls, 1);
+    expect(loader.calls, 1);
     expect(identical(first, second), isTrue);
   });
 }


### PR DESCRIPTION
## Why
- simplify `FlashcardRepository` by removing data retrieval logic
- allow injection of a loader class and improve testability

## What
- introduce `FlashcardLoader` interface and `HiveFlashcardLoader` implementation
- update `FlashcardRepository` to depend on the loader
- adjust existing tests and add unit test for loader


------
https://chatgpt.com/codex/tasks/task_e_68645c5387ec832ab08271702d61ea5c