### PR TITLE
Refactor HomeTab stats logic

### DIFF
--- a/lib/home_stats_provider.dart
+++ b/lib/home_stats_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'models/quiz_stat.dart';
+
+class AggregateStatsNotifier extends StateNotifier<Map<String, int>> {
+  AggregateStatsNotifier() : super(const {'questions': 0, 'correct': 0});
+
+  void aggregate(Iterable<QuizStat> entries) {
+    int questions = 0;
+    int correct = 0;
+    for (final m in entries) {
+      questions += m.questionCount;
+      correct += m.correctCount;
+    }
+    state = {'questions': questions, 'correct': correct};
+  }
+}
+
+final aggregateStatsProvider =
+    StateNotifierProvider<AggregateStatsNotifier, Map<String, int>>((ref) {
+  return AggregateStatsNotifier();
+});

--- a/test/home_stats_provider_test.dart
+++ b/test/home_stats_provider_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tango/home_stats_provider.dart';
+import 'package:tango/models/quiz_stat.dart';
+
+void main() {
+  test('aggregates questions and correct count', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(aggregateStatsProvider.notifier);
+
+    final entries = [
+      QuizStat(
+        timestamp: DateTime.now(),
+        questionCount: 5,
+        correctCount: 3,
+        durationSeconds: 10,
+        wordIds: const [],
+        results: const [],
+      ),
+      QuizStat(
+        timestamp: DateTime.now(),
+        questionCount: 7,
+        correctCount: 4,
+        durationSeconds: 15,
+        wordIds: const [],
+        results: const [],
+      ),
+    ];
+
+    notifier.aggregate(entries);
+    final result = container.read(aggregateStatsProvider);
+    expect(result['questions'], 12);
+    expect(result['correct'], 7);
+  });
+}


### PR DESCRIPTION
## Why
Separated quiz statistics aggregation from UI to simplify `HomeTabContent` and enable easier testing.

## What
- Added `AggregateStatsNotifier` and `aggregateStatsProvider`.
- Converted `HomeTabContent` to a `ConsumerWidget` and used the provider.
- Added provider unit test.

## How
- Implemented notifier in `lib/home_stats_provider.dart`.
- Updated widget logic in `lib/tabs_content/home_tab_content.dart`.
- Created `test/home_stats_provider_test.dart`.

- [ ] Code formatted


------
https://chatgpt.com/codex/tasks/task_e_6864601b0f60832aaefa315750801c40