### PR TITLE
Add word history controller and refactor detail view

### DIFF
--- a/lib/controllers/word_history_controller.dart
+++ b/lib/controllers/word_history_controller.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+
+import '../flashcard_model.dart';
+import '../services/history_service.dart';
+
+class _ViewState {
+  final List<Flashcard> list;
+  final int index;
+  const _ViewState(this.list, this.index);
+}
+
+/// Controller to track viewed flashcards and navigate history.
+class WordHistoryController extends ChangeNotifier {
+  final HistoryService _historyService;
+  final List<_ViewState> _history = [];
+  int _historyIndex = -1;
+  bool _suppressPush = false;
+
+  WordHistoryController([HistoryService? service])
+      : _historyService = service ?? HistoryService();
+
+  void initialize(List<Flashcard> list, int index) {
+    _history
+      ..clear()
+      ..add(_ViewState(list, index));
+    _historyIndex = 0;
+    _addEntry();
+    notifyListeners();
+  }
+
+  bool get canGoBack => _historyIndex > 0;
+  bool get canGoForward =>
+      _historyIndex >= 0 && _historyIndex < _history.length - 1;
+
+  List<Flashcard> get currentList => _history[_historyIndex].list;
+  int get currentIndex => _history[_historyIndex].index;
+  Flashcard get currentFlashcard => currentList[currentIndex];
+
+  void setPage(int index) {
+    _history[_historyIndex] = _ViewState(currentList, index);
+    _addEntry();
+    _push();
+  }
+
+  void openGroup(List<Flashcard> list, int index) {
+    _jumpTo(_ViewState(list, index), addToHistory: true);
+  }
+
+  void back() {
+    if (canGoBack) {
+      _historyIndex--;
+      _jumpTo(_history[_historyIndex]);
+    }
+  }
+
+  void forward() {
+    if (canGoForward) {
+      _historyIndex++;
+      _jumpTo(_history[_historyIndex]);
+    }
+  }
+
+  void _push() {
+    if (_suppressPush) {
+      _suppressPush = false;
+      return;
+    }
+    if (_historyIndex < _history.length - 1) {
+      _history.removeRange(_historyIndex + 1, _history.length);
+    }
+    _history.add(_ViewState(currentList, currentIndex));
+    _historyIndex = _history.length - 1;
+    notifyListeners();
+  }
+
+  void _jumpTo(_ViewState view, {bool addToHistory = false}) {
+    _suppressPush = true;
+    _history[_historyIndex] = view;
+    if (addToHistory) {
+      if (_historyIndex < _history.length - 1) {
+        _history.removeRange(_historyIndex + 1, _history.length);
+      }
+      _history.add(_ViewState(view.list, view.index));
+      _historyIndex = _history.length - 1;
+    }
+    _addEntry();
+    notifyListeners();
+  }
+
+  Future<void> _addEntry() async {
+    await _historyService.addView(currentFlashcard.id);
+  }
+}

--- a/lib/widgets/word_detail/flashcard_detail_view.dart
+++ b/lib/widgets/word_detail/flashcard_detail_view.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import '../../flashcard_model.dart';
+import '../../star_color.dart';
+import '../detail_item.dart';
+import '../favorite_star_button.dart';
+import 'related_terms_section.dart';
+
+class FlashcardDetailView extends StatelessWidget {
+  final Flashcard card;
+  final Map<StarColor, bool> favoriteStatus;
+  final ValueChanged<StarColor> onToggleFavorite;
+  final List<Flashcard> relatedSource;
+  final void Function(Flashcard origin, Flashcard selected) onSelectRelated;
+
+  const FlashcardDetailView({
+    super.key,
+    required this.card,
+    required this.favoriteStatus,
+    required this.onToggleFavorite,
+    required this.relatedSource,
+    required this.onSelectRelated,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    String categories =
+        '${card.categoryLarge} > ${card.categoryMedium} > ${card.categorySmall}';
+    if (card.categoryItem != card.categorySmall &&
+        card.categoryItem.isNotEmpty &&
+        !['（小分類全体）', '[脅威の種類]', '[マルウェア・不正プログラム]', 'nan', 'ー']
+            .contains(card.categoryItem)) {
+      categories += ' > ${card.categoryItem}';
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  card.term,
+                  style: Theme.of(context).textTheme.displaySmall?.copyWith(
+                        fontSize: 26,
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  FavoriteStarButton(
+                    isFavorite: favoriteStatus[StarColor.red] ?? false,
+                    activeColor: Theme.of(context).colorScheme.error,
+                    inactiveColor: Theme.of(context).colorScheme.outline,
+                    onPressed: () => onToggleFavorite(StarColor.red),
+                    tooltip: '赤星',
+                  ),
+                  FavoriteStarButton(
+                    isFavorite: favoriteStatus[StarColor.yellow] ?? false,
+                    activeColor: Theme.of(context).colorScheme.secondary,
+                    inactiveColor: Theme.of(context).colorScheme.outline,
+                    onPressed: () => onToggleFavorite(StarColor.yellow),
+                    tooltip: '黄星',
+                  ),
+                  FavoriteStarButton(
+                    isFavorite: favoriteStatus[StarColor.blue] ?? false,
+                    activeColor: Theme.of(context).colorScheme.primary,
+                    inactiveColor: Theme.of(context).colorScheme.outline,
+                    onPressed: () => onToggleFavorite(StarColor.blue),
+                    tooltip: '青星',
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          if (card.reading.isNotEmpty && card.reading != 'nan' && card.reading != 'ー')
+            Text(
+              '読み: ${card.reading}',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontStyle: FontStyle.italic,
+                    color: Theme.of(context)
+                        .textTheme
+                        .bodyMedium
+                        ?.color
+                        ?.withOpacity(0.7),
+                  ),
+            ),
+          const SizedBox(height: 12),
+          DetailItem(
+            label: '重要度:',
+            value: '★' * card.importance.toInt() +
+                (card.importance - card.importance.toInt() > 0 ? '☆' : '') +
+                ' (${card.importance.toStringAsFixed(1)})',
+          ),
+          DetailItem(label: 'カテゴリー:', value: categories),
+          const Divider(height: 24, thickness: 0.8),
+          DetailItem(label: '概要 (Description):', value: card.description),
+          DetailItem(label: '解説 (Practical Tip):', value: card.practicalTip),
+          DetailItem(label: '出題例 (Exam Example):', value: card.examExample),
+          DetailItem(label: '試験ポイント (Exam Point):', value: card.examPoint),
+          RelatedTermsSection(
+            card: card,
+            source: relatedSource,
+            onSelected: onSelectRelated,
+          ),
+          DetailItem(label: 'タグ (Tags):', value: card.tags?.join('、')),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/word_detail/related_terms_section.dart
+++ b/lib/widgets/word_detail/related_terms_section.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../../flashcard_model.dart';
+
+class RelatedTermsSection extends StatelessWidget {
+  final Flashcard card;
+  final List<Flashcard> source;
+  final void Function(Flashcard origin, Flashcard selected) onSelected;
+
+  const RelatedTermsSection({
+    super.key,
+    required this.card,
+    required this.source,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ids = card.relatedIds;
+    if (ids == null || ids.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    List<Widget> buttons = [];
+    for (final id in ids) {
+      Flashcard? related;
+      try {
+        related = source.firstWhere((c) => c.id == id);
+      } catch (_) {
+        related = null;
+      }
+      final label = related?.term ?? id;
+      buttons.add(
+        Padding(
+          padding: const EdgeInsets.only(right: 8.0, bottom: 4.0),
+          child: TextButton(
+            onPressed: related != null
+                ? () => _showDialog(context, related!, card)
+                : null,
+            child: Text(label),
+          ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '関連用語 (Related Terms):',
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Wrap(children: buttons),
+        ],
+      ),
+    );
+  }
+
+  void _showDialog(BuildContext context, Flashcard selected, Flashcard origin) {
+    showDialog(
+      context: context,
+      barrierDismissible: true,
+      builder: (context) => GestureDetector(
+        onTap: () {
+          Navigator.of(context).pop();
+          onSelected(origin, selected);
+        },
+        child: AlertDialog(
+          title: Text(selected.term),
+          content: Text(selected.description),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('閉じる'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Why
- navigation history was handled inside the widget
- large widget logic for word details needed splitting up

## What
- introduce `WordHistoryController` to manage flashcard history
- move detail UI into `FlashcardDetailView` and `RelatedTermsSection`
- keep `WordDetailContent` as a thin widget using the controller

## How
- new controller in `lib/controllers/word_history_controller.dart`
- new widgets under `lib/widgets/word_detail/`
- update `WordDetailContent` to delegate to the controller


------
https://chatgpt.com/codex/tasks/task_e_68648e56c350832ab690346eb7d2f07c