### PR TITLE
Extract history chart service

### DIFF
--- a/lib/learning_history_detail_screen.dart
+++ b/lib/learning_history_detail_screen.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:intl/intl.dart';
-import 'dart:math' as math;
 
 import 'package:tango/history_entry_model.dart';
 import 'constants.dart';
 import 'models/quiz_stat.dart';
+import 'services/history_chart_service.dart';
+import 'widgets/history_charts/bar_chart.dart';
+import 'widgets/history_charts/line_chart.dart';
 
 enum ViewMode { day, week, month }
 
@@ -23,6 +24,7 @@ class _LearningHistoryDetailScreenState
     extends State<LearningHistoryDetailScreen> {
   late Box<HistoryEntry> _historyBox;
   late Box<QuizStat> _quizStatsBox;
+  late HistoryChartService _chartService;
   ViewMode _mode = ViewMode.day;
   int _offset = 0;
 
@@ -31,218 +33,7 @@ class _LearningHistoryDetailScreenState
     super.initState();
     _historyBox = Hive.box<HistoryEntry>(historyBoxName);
     _quizStatsBox = Hive.box<QuizStat>(quizStatsBoxName);
-  }
-
-  double _niceInterval(double maxValue) {
-    if (maxValue <= 0) return 1;
-    final rawStep = maxValue / 5;
-    final exponent = (math.log(rawStep) / math.ln10).floor();
-    final magnitude = math.pow(10, exponent).toDouble();
-    final residual = rawStep / magnitude;
-    double step;
-    if (residual > 5) {
-      step = 10;
-    } else if (residual > 2) {
-      step = 5;
-    } else if (residual > 1) {
-      step = 2;
-    } else {
-      step = 1;
-    }
-    return (step * magnitude).toDouble();
-  }
-
-  DateTime _addMonths(DateTime date, int months) {
-    return DateTime(date.year, date.month + months, 1);
-  }
-
-  List<DateTimeRange> _currentRanges() {
-    final now = DateTime.now();
-    switch (_mode) {
-      case ViewMode.day:
-        final end = DateTime(now.year, now.month, now.day)
-            .add(Duration(days: _offset * 7));
-        final start = end.subtract(const Duration(days: 6));
-        return List.generate(7, (i) {
-          final s = start.add(Duration(days: i));
-          return DateTimeRange(start: s, end: s.add(const Duration(days: 1)));
-        });
-      case ViewMode.week:
-        const points = 6;
-        final weekStart = DateTime(now.year, now.month, now.day)
-            .subtract(Duration(days: now.weekday - 1));
-        final end = weekStart.add(Duration(days: 7 * _offset));
-        final start = end.subtract(Duration(days: 7 * (points - 1)));
-        return List.generate(points, (i) {
-          final s = start.add(Duration(days: 7 * i));
-          return DateTimeRange(start: s, end: s.add(const Duration(days: 7)));
-        });
-      case ViewMode.month:
-        const points = 6;
-        final monthStart = DateTime(now.year, now.month, 1);
-        final end = _addMonths(monthStart, _offset);
-        final start = _addMonths(end, -(points - 1));
-        return List.generate(points, (i) {
-          final s = _addMonths(start, i);
-          return DateTimeRange(start: s, end: _addMonths(s, 1));
-        });
-    }
-  }
-
-  List<FlSpot> _learnedSpots(List<DateTimeRange> ranges) {
-    return List.generate(ranges.length, (i) {
-      final r = ranges[i];
-      final count = _historyBox.values
-          .cast<HistoryEntry>()
-          .where((e) =>
-              e.timestamp.isAfter(r.start) && e.timestamp.isBefore(r.end))
-          .map((e) => e.wordId)
-          .toSet()
-          .length;
-      return FlSpot(i.toDouble(), count.toDouble());
-    });
-  }
-
-  List<FlSpot> _accuracySpots(List<DateTimeRange> ranges) {
-    return List.generate(ranges.length, (i) {
-      final r = ranges[i];
-      int q = 0;
-      int c = 0;
-      for (var m in _quizStatsBox.values) {
-        final ts = m.timestamp;
-        if (ts.isAfter(r.start) && ts.isBefore(r.end)) {
-          q += m.questionCount;
-          c += m.correctCount;
-        }
-      }
-      final acc = q == 0 ? 0.0 : c / q * 100;
-      return FlSpot(i.toDouble(), acc);
-    });
-  }
-
-  List<BarChartGroupData> _timeBars(List<DateTimeRange> ranges) {
-    return List.generate(ranges.length, (i) {
-      final r = ranges[i];
-      int secs = 0;
-      for (var m in _quizStatsBox.values) {
-        final ts = m.timestamp;
-        if (ts.isAfter(r.start) && ts.isBefore(r.end)) {
-          secs += m.durationSeconds;
-        }
-      }
-      return BarChartGroupData(
-          x: i, barRods: [BarChartRodData(toY: secs.toDouble() / 60.0)]);
-    });
-  }
-
-  Widget _buildLineChart(List<FlSpot> spots, List<String> labels,
-      {bool isPercent = false}) {
-    final maxVal = spots.fold<double>(0, (p, e) => math.max(p, e.y));
-    final range = isPercent ? 100.0 : maxVal;
-    final interval = _niceInterval(range);
-    final maxY = isPercent ? 100.0 : (range / interval).ceil() * interval;
-    return LineChart(
-      LineChartData(
-        lineBarsData: [LineChartBarData(spots: spots, isCurved: false)],
-        minY: 0,
-        maxY: maxY,
-        titlesData: FlTitlesData(
-          bottomTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              interval: 1,
-              getTitlesWidget: (value, meta) {
-                final idx = value.toInt();
-                if (idx < 0 || idx >= labels.length) {
-                  return const SizedBox.shrink();
-                }
-                return Text(labels[idx],
-                    style: Theme.of(context)
-                        .textTheme
-                        .labelSmall
-                        ?.copyWith(fontSize: 10));
-              },
-            ),
-          ),
-          leftTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              interval: interval,
-              reservedSize: 32,
-              getTitlesWidget: (value, meta) {
-                return Text(value.toInt().toString(),
-                    style: Theme.of(context)
-                        .textTheme
-                        .labelSmall
-                        ?.copyWith(fontSize: 10));
-              },
-            ),
-          ),
-          topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-          rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        ),
-        gridData: FlGridData(show: false),
-        borderData: FlBorderData(show: true),
-      ),
-    );
-  }
-
-  Widget _buildBarChart(List<BarChartGroupData> bars, List<String> labels) {
-    double maxVal = 0;
-    for (final g in bars) {
-      for (final r in g.barRods) {
-        maxVal = math.max(maxVal, r.toY);
-      }
-    }
-    double interval = 10.0;
-    while (maxVal / interval > 6) {
-      interval *= 2;
-      if (interval == 40) interval = 60;
-    }
-    final maxY = math.max((maxVal / interval).ceil() * interval, interval);
-    return BarChart(
-      BarChartData(
-        barGroups: bars,
-        maxY: maxY,
-        titlesData: FlTitlesData(
-          bottomTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              interval: 1,
-              getTitlesWidget: (value, meta) {
-                final idx = value.toInt();
-                if (idx < 0 || idx >= labels.length) {
-                  return const SizedBox.shrink();
-                }
-                return Text(labels[idx],
-                    style: Theme.of(context)
-                        .textTheme
-                        .labelSmall
-                        ?.copyWith(fontSize: 10));
-              },
-            ),
-          ),
-          leftTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              interval: interval,
-              reservedSize: 32,
-              getTitlesWidget: (value, meta) => Text(
-                value.toInt().toString(),
-                style: Theme.of(context)
-                    .textTheme
-                    .labelSmall
-                    ?.copyWith(fontSize: 10),
-              ),
-            ),
-          ),
-          topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-          rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        ),
-        gridData: FlGridData(show: false),
-        borderData: FlBorderData(show: true),
-      ),
-    );
+    _chartService = HistoryChartService(_historyBox, _quizStatsBox);
   }
 
   @override
@@ -253,16 +44,16 @@ class _LearningHistoryDetailScreenState
         return ValueListenableBuilder(
           valueListenable: _quizStatsBox.listenable(),
           builder: (context, __, ___) {
-            final ranges = _currentRanges();
+            final ranges = _chartService.currentRanges(_mode, _offset);
             final dateFormat = _mode == ViewMode.month
                 ? DateFormat('yyyy/MM')
                 : DateFormat('M/d');
             final labels =
                 ranges.map((r) => dateFormat.format(r.start)).toList();
 
-            final learned = _learnedSpots(ranges);
-            final accuracy = _accuracySpots(ranges);
-            final timeBars = _timeBars(ranges);
+            final learned = _chartService.learnedSpots(ranges);
+            final accuracy = _chartService.accuracySpots(ranges);
+            final timeBars = _chartService.timeBars(ranges);
 
             return ListView(
               padding: const EdgeInsets.all(16),
@@ -298,7 +89,7 @@ class _LearningHistoryDetailScreenState
                                 }
                               });
                             },
-                            child: _buildLineChart(learned, labels),
+                            child: HistoryLineChart(spots: learned, labels: labels),
                           ),
                         ),
                       ],
@@ -325,8 +116,11 @@ class _LearningHistoryDetailScreenState
                                 }
                               });
                             },
-                            child: _buildLineChart(accuracy, labels,
-                                isPercent: true),
+                            child: HistoryLineChart(
+                              spots: accuracy,
+                              labels: labels,
+                              isPercent: true,
+                            ),
                           ),
                         ),
                       ],
@@ -353,7 +147,7 @@ class _LearningHistoryDetailScreenState
                                 }
                               });
                             },
-                            child: _buildBarChart(timeBars, labels),
+                            child: HistoryBarChart(bars: timeBars, labels: labels),
                           ),
                         ),
                       ],

--- a/lib/services/history_chart_service.dart
+++ b/lib/services/history_chart_service.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../history_entry_model.dart';
+import '../models/quiz_stat.dart';
+import '../constants.dart';
+import '../learning_history_detail_screen.dart';
+
+class HistoryChartService {
+  final Box<HistoryEntry> _historyBox;
+  final Box<QuizStat> _quizStatsBox;
+
+  HistoryChartService([
+    Box<HistoryEntry>? historyBox,
+    Box<QuizStat>? quizStatsBox,
+  ])  : _historyBox = historyBox ?? Hive.box<HistoryEntry>(historyBoxName),
+        _quizStatsBox = quizStatsBox ?? Hive.box<QuizStat>(quizStatsBoxName);
+
+  DateTime _addMonths(DateTime date, int months) {
+    return DateTime(date.year, date.month + months, 1);
+  }
+
+  List<DateTimeRange> currentRanges(ViewMode mode, int offset) {
+    final now = DateTime.now();
+    switch (mode) {
+      case ViewMode.day:
+        final end = DateTime(now.year, now.month, now.day)
+            .add(Duration(days: offset * 7));
+        final start = end.subtract(const Duration(days: 6));
+        return List.generate(7, (i) {
+          final s = start.add(Duration(days: i));
+          return DateTimeRange(start: s, end: s.add(const Duration(days: 1)));
+        });
+      case ViewMode.week:
+        const points = 6;
+        final weekStart =
+            DateTime(now.year, now.month, now.day).subtract(Duration(days: now.weekday - 1));
+        final end = weekStart.add(Duration(days: 7 * offset));
+        final start = end.subtract(Duration(days: 7 * (points - 1)));
+        return List.generate(points, (i) {
+          final s = start.add(Duration(days: 7 * i));
+          return DateTimeRange(start: s, end: s.add(const Duration(days: 7)));
+        });
+      case ViewMode.month:
+        const points = 6;
+        final monthStart = DateTime(now.year, now.month, 1);
+        final end = _addMonths(monthStart, offset);
+        final start = _addMonths(end, -(points - 1));
+        return List.generate(points, (i) {
+          final s = _addMonths(start, i);
+          return DateTimeRange(start: s, end: _addMonths(s, 1));
+        });
+    }
+  }
+
+  List<FlSpot> learnedSpots(List<DateTimeRange> ranges) {
+    return List.generate(ranges.length, (i) {
+      final r = ranges[i];
+      final count = _historyBox.values
+          .where((e) => e.timestamp.isAfter(r.start) && e.timestamp.isBefore(r.end))
+          .map((e) => e.wordId)
+          .toSet()
+          .length;
+      return FlSpot(i.toDouble(), count.toDouble());
+    });
+  }
+
+  List<FlSpot> accuracySpots(List<DateTimeRange> ranges) {
+    return List.generate(ranges.length, (i) {
+      final r = ranges[i];
+      int q = 0;
+      int c = 0;
+      for (var m in _quizStatsBox.values) {
+        final ts = m.timestamp;
+        if (ts.isAfter(r.start) && ts.isBefore(r.end)) {
+          q += m.questionCount;
+          c += m.correctCount;
+        }
+      }
+      final acc = q == 0 ? 0.0 : c / q * 100;
+      return FlSpot(i.toDouble(), acc);
+    });
+  }
+
+  List<BarChartGroupData> timeBars(List<DateTimeRange> ranges) {
+    return List.generate(ranges.length, (i) {
+      final r = ranges[i];
+      int secs = 0;
+      for (var m in _quizStatsBox.values) {
+        final ts = m.timestamp;
+        if (ts.isAfter(r.start) && ts.isBefore(r.end)) {
+          secs += m.durationSeconds;
+        }
+      }
+      return BarChartGroupData(x: i, barRods: [BarChartRodData(toY: secs.toDouble() / 60.0)]);
+    });
+  }
+}

--- a/lib/widgets/history_charts/bar_chart.dart
+++ b/lib/widgets/history_charts/bar_chart.dart
@@ -1,0 +1,72 @@
+import 'dart:math' as math;
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class HistoryBarChart extends StatelessWidget {
+  final List<BarChartGroupData> bars;
+  final List<String> labels;
+
+  const HistoryBarChart({
+    super.key,
+    required this.bars,
+    required this.labels,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    double maxVal = 0;
+    for (final g in bars) {
+      for (final r in g.barRods) {
+        maxVal = math.max(maxVal, r.toY);
+      }
+    }
+    double interval = 10.0;
+    while (maxVal / interval > 6) {
+      interval *= 2;
+      if (interval == 40) interval = 60;
+    }
+    final maxY = math.max((maxVal / interval).ceil() * interval, interval);
+    return BarChart(
+      BarChartData(
+        barGroups: bars,
+        maxY: maxY,
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              interval: 1,
+              getTitlesWidget: (value, meta) {
+                final idx = value.toInt();
+                if (idx < 0 || idx >= labels.length) {
+                  return const SizedBox.shrink();
+                }
+                return Text(
+                  labels[idx],
+                  style:
+                      Theme.of(context).textTheme.labelSmall?.copyWith(fontSize: 10),
+                );
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              interval: interval,
+              reservedSize: 32,
+              getTitlesWidget: (value, meta) => Text(
+                value.toInt().toString(),
+                style:
+                    Theme.of(context).textTheme.labelSmall?.copyWith(fontSize: 10),
+              ),
+            ),
+          ),
+          topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        ),
+        gridData: FlGridData(show: false),
+        borderData: FlBorderData(show: true),
+      ),
+    );
+  }
+}

--- a/lib/widgets/history_charts/line_chart.dart
+++ b/lib/widgets/history_charts/line_chart.dart
@@ -1,0 +1,88 @@
+import 'dart:math' as math;
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class HistoryLineChart extends StatelessWidget {
+  final List<FlSpot> spots;
+  final List<String> labels;
+  final bool isPercent;
+
+  const HistoryLineChart({
+    super.key,
+    required this.spots,
+    required this.labels,
+    this.isPercent = false,
+  });
+
+  double _niceInterval(double maxValue) {
+    if (maxValue <= 0) return 1;
+    final rawStep = maxValue / 5;
+    final exponent = (math.log(rawStep) / math.ln10).floor();
+    final magnitude = math.pow(10, exponent).toDouble();
+    final residual = rawStep / magnitude;
+    double step;
+    if (residual > 5) {
+      step = 10;
+    } else if (residual > 2) {
+      step = 5;
+    } else if (residual > 1) {
+      step = 2;
+    } else {
+      step = 1;
+    }
+    return (step * magnitude).toDouble();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxVal = spots.fold<double>(0, (p, e) => math.max(p, e.y));
+    final range = isPercent ? 100.0 : maxVal;
+    final interval = _niceInterval(range);
+    final maxY = isPercent ? 100.0 : (range / interval).ceil() * interval;
+    return LineChart(
+      LineChartData(
+        lineBarsData: [LineChartBarData(spots: spots, isCurved: false)],
+        minY: 0,
+        maxY: maxY,
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              interval: 1,
+              getTitlesWidget: (value, meta) {
+                final idx = value.toInt();
+                if (idx < 0 || idx >= labels.length) {
+                  return const SizedBox.shrink();
+                }
+                return Text(
+                  labels[idx],
+                  style:
+                      Theme.of(context).textTheme.labelSmall?.copyWith(fontSize: 10),
+                );
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              interval: interval,
+              reservedSize: 32,
+              getTitlesWidget: (value, meta) {
+                return Text(
+                  value.toInt().toString(),
+                  style:
+                      Theme.of(context).textTheme.labelSmall?.copyWith(fontSize: 10),
+                );
+              },
+            ),
+          ),
+          topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        ),
+        gridData: FlGridData(show: false),
+        borderData: FlBorderData(show: true),
+      ),
+    );
+  }
+}

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tango/history_entry_model.dart';
+import 'package:tango/models/quiz_stat.dart';
+import 'package:tango/services/history_chart_service.dart';
+import 'package:tango/constants.dart';
+import 'package:tango/learning_history_detail_screen.dart';
+
+void main() {
+  late Directory dir;
+  late Box<HistoryEntry> historyBox;
+  late Box<QuizStat> quizBox;
+  late HistoryChartService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(HistoryEntryAdapter());
+    Hive.registerAdapter(QuizStatAdapter());
+    historyBox = await Hive.openBox<HistoryEntry>(historyBoxName);
+    quizBox = await Hive.openBox<QuizStat>(quizStatsBoxName);
+    service = HistoryChartService(historyBox, quizBox);
+  });
+
+  tearDown(() async {
+    await historyBox.close();
+    await quizBox.close();
+    await Hive.deleteBoxFromDisk(historyBoxName);
+    await Hive.deleteBoxFromDisk(quizStatsBoxName);
+    await dir.delete(recursive: true);
+  });
+
+  test('calculates chart data', () async {
+    final now = DateTime.now();
+    await historyBox.put('a', HistoryEntry(wordId: 'a', timestamp: now));
+    await historyBox.put('b', HistoryEntry(wordId: 'b', timestamp: now));
+    await historyBox.put('a2', HistoryEntry(wordId: 'a', timestamp: now));
+
+    await quizBox.add(QuizStat(
+      timestamp: now,
+      questionCount: 5,
+      correctCount: 4,
+      durationSeconds: 120,
+      wordIds: const [],
+      results: const [],
+    ));
+
+    final ranges = [
+      DateTimeRange(start: now.subtract(const Duration(days: 1)), end: now.add(const Duration(days: 1))),
+    ];
+
+    final learned = service.learnedSpots(ranges);
+    expect(learned.first.y, 2);
+
+    final acc = service.accuracySpots(ranges);
+    expect(acc.first.y, closeTo(80.0, 0.01));
+
+    final bars = service.timeBars(ranges);
+    expect(bars.first.barRods.first.toY, closeTo(2.0, 0.01));
+  });
+
+  test('provides range lengths', () {
+    expect(service.currentRanges(ViewMode.day, 0).length, 7);
+    expect(service.currentRanges(ViewMode.week, 0).length, 6);
+    expect(service.currentRanges(ViewMode.month, 0).length, 6);
+  });
+}


### PR DESCRIPTION
## Why
- history chart calculations clutter `LearningHistoryDetailScreen`
- widgets for charts can be reused

## What
- add `HistoryChartService` for range and spot calculations
- move chart widgets into `lib/widgets/history_charts/`
- update `LearningHistoryDetailScreen` to use new service and widgets
- add tests for `HistoryChartService`

## How
- `dart format` and `flutter test` failed due to missing SDK in the environment


------
https://chatgpt.com/codex/tasks/task_e_6864a0582b80832a9a4a5c519ed3eaf0