### PR TITLE
Refactor quiz logic into controller

### DIFF
--- a/lib/controllers/quiz_controller.dart
+++ b/lib/controllers/quiz_controller.dart
@@ -1,0 +1,107 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+
+import '../flashcard_model.dart';
+import '../quiz_setup_screen.dart';
+import '../services/learning_repository.dart';
+import '../services/review_queue_service.dart';
+
+class QuizController extends ChangeNotifier {
+  final List<Flashcard> words;
+  final int totalQuestions;
+  final QuizType quizType;
+
+  LearningRepository? _learningRepo;
+  final ReviewQueueService _queueService;
+
+  List<Flashcard>? _allWords;
+  int _currentIndex = 0;
+  int _score = 0;
+  final List<bool> _answerResults = [];
+  late DateTime _startTime;
+  late Flashcard _currentFlashcard;
+  List<Flashcard> _choices = [];
+  bool _answered = false;
+  String? _selectedTerm;
+
+  QuizController({
+    required this.words,
+    required this.totalQuestions,
+    required this.quizType,
+    ReviewQueueService? queueService,
+  }) : _queueService = queueService ?? ReviewQueueService() {
+    _startTime = DateTime.now();
+    _loadQuestion();
+  }
+
+  Future<LearningRepository> _repo() async {
+    _learningRepo ??= await LearningRepository.open();
+    return _learningRepo!;
+  }
+
+  void setAllWords(List<Flashcard> list) {
+    _allWords = list;
+    _generateChoices();
+    notifyListeners();
+  }
+
+  List<Flashcard> _getAllWords() {
+    return _allWords ?? words;
+  }
+
+  void _generateChoices() {
+    final all = _getAllWords();
+    final pool = List<Flashcard>.from(all)
+      ..removeWhere((e) => e.id == _currentFlashcard.id);
+    pool.shuffle(Random());
+    final incorrect = pool.take(3).toList();
+    _choices = [_currentFlashcard, ...incorrect]..shuffle(Random());
+  }
+
+  void _loadQuestion() {
+    _currentFlashcard = words[_currentIndex];
+    _generateChoices();
+    _answered = false;
+    _selectedTerm = null;
+  }
+
+  Future<void> _recordAnswer(bool correct) async {
+    final repo = await _repo();
+    final id = _currentFlashcard.id;
+    if (correct) {
+      await repo.incrementCorrect(id);
+      await _queueService.clearWeak(id);
+    } else {
+      await repo.incrementWrong(id);
+      await _queueService.push(id);
+    }
+    await repo.markReviewed(id);
+  }
+
+  Future<void> select(String term) async {
+    if (_answered) return;
+    _selectedTerm = term;
+    final correct = term == _currentFlashcard.term;
+    if (correct) _score++;
+    _answerResults.add(correct);
+    await _recordAnswer(correct);
+    _answered = true;
+    notifyListeners();
+  }
+
+  void next() {
+    if (_currentIndex + 1 >= totalQuestions) return;
+    _currentIndex++;
+    _loadQuestion();
+    notifyListeners();
+  }
+
+  Flashcard get currentFlashcard => _currentFlashcard;
+  List<Flashcard> get choices => _choices;
+  bool get answered => _answered;
+  int get currentIndex => _currentIndex;
+  int get score => _score;
+  String? get selectedTerm => _selectedTerm;
+  List<bool> get answerResults => List.unmodifiable(_answerResults);
+  DateTime get startTime => _startTime;
+}

--- a/lib/widgets/quiz/answer_view.dart
+++ b/lib/widgets/quiz/answer_view.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import '../../flashcard_model.dart';
+import '../../quiz_setup_screen.dart';
+import '../../star_color.dart';
+
+class AnswerView extends StatelessWidget {
+  final bool correct;
+  final QuizType quizType;
+  final Flashcard current;
+  final List<Flashcard> choices;
+  final Widget Function(String wordId, StarColor colorKey, Color color)
+      buildStarIcon;
+  final VoidCallback onNext;
+
+  const AnswerView({
+    super.key,
+    required this.correct,
+    required this.quizType,
+    required this.current,
+    required this.choices,
+    required this.buildStarIcon,
+    required this.onNext,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 16),
+        Icon(
+          correct ? Icons.circle : Icons.close,
+          color: correct
+              ? Theme.of(context).colorScheme.secondary
+              : Theme.of(context).colorScheme.error,
+          size: 64,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          correct ? '正解！' : '不正解',
+          textAlign: TextAlign.center,
+          style: Theme.of(context)
+              .textTheme
+              .titleMedium
+              ?.copyWith(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 24),
+        if (quizType == QuizType.multipleChoice) ...[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              buildStarIcon(current.id, StarColor.red,
+                  Theme.of(context).colorScheme.error),
+              buildStarIcon(current.id, StarColor.yellow,
+                  Theme.of(context).colorScheme.secondary),
+              buildStarIcon(current.id, StarColor.blue,
+                  Theme.of(context).colorScheme.primary),
+            ],
+          ),
+        ] else ...[
+          Column(
+            children: choices
+                .map(
+                  (c) => Card(
+                    margin: const EdgeInsets.symmetric(vertical: 4),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  c.term,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .titleMedium
+                                      ?.copyWith(fontWeight: FontWeight.bold),
+                                ),
+                              ),
+                              Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  buildStarIcon(c.id, StarColor.red,
+                                      Theme.of(context).colorScheme.error),
+                                  buildStarIcon(c.id, StarColor.yellow,
+                                      Theme.of(context).colorScheme.secondary),
+                                  buildStarIcon(c.id, StarColor.blue,
+                                      Theme.of(context).colorScheme.primary),
+                                ],
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          Text(c.description),
+                        ],
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ],
+        const SizedBox(height: 24),
+        ElevatedButton(
+          onPressed: onNext,
+          child: const Text('次の問題へ'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/quiz/choice_button.dart
+++ b/lib/widgets/quiz/choice_button.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../../flashcard_model.dart';
+
+class ChoiceButton extends StatelessWidget {
+  final Flashcard card;
+  final VoidCallback onPressed;
+
+  const ChoiceButton({
+    super.key,
+    required this.card,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        child: Text(card.term),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Why
Centralizing quiz state management makes the quiz screen simpler and reusable.

## What
- Added `QuizController` to handle answer tracking and queue updates
- Extracted new widgets `ChoiceButton` and `AnswerView`
- Updated `QuizInProgressScreen` to use the controller and widgets

## How
- `dart format` was attempted but the tool was unavailable in the environment


------
https://chatgpt.com/codex/tasks/task_e_6864aba37824832a93193c5b9a8faa1d