### PR TITLE
Centralize Hive box initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'theme_mode_provider.dart';
 import 'models/saved_theme_mode.dart';
 import 'flashcard_repository.dart';
 import 'flashcard_repository_provider.dart';
+import 'services/box_initializer.dart';
 
 const _secureKeyName = 'hive_encryption_key';
 const _secureStorage = FlutterSecureStorage();
@@ -79,20 +80,7 @@ Future<void> main() async {
   final key = await _getEncryptionKey();
   final cipher = HiveAesCipher(key);
 
-  final openBoxTasks = [
-    () => _openBoxWithMigration<Map>(favoritesBoxName, cipher),
-    () => _openBoxWithMigration<HistoryEntry>(historyBoxName, cipher),
-    () => _openBoxWithMigration<QuizStat>(quizStatsBoxName, cipher),
-    () => _openBoxWithMigration<FlashcardState>(flashcardStateBoxName, cipher),
-    () => _openBoxWithMigration<Word>(WordRepository.boxName, cipher),
-    () => _openBoxWithMigration<LearningStat>(LearningRepository.boxName, cipher),
-    () => _openBoxWithMigration<SessionLog>(sessionLogBoxName, cipher),
-    () => _openBoxWithMigration<ReviewQueue>(reviewQueueBoxName, cipher),
-    () => _openBoxWithMigration<SavedThemeMode>(settingsBoxName, cipher),
-  ];
-  for (final task in openBoxTasks) {
-    await task();
-  }
+  await openAllBoxes(cipher);
 
   final theme = ThemeProvider();
   await theme.loadAppPreferences();

--- a/lib/services/box_initializer.dart
+++ b/lib/services/box_initializer.dart
@@ -1,0 +1,48 @@
+import 'package:hive/hive.dart';
+
+import '../constants.dart';
+import '../history_entry_model.dart';
+import '../models/flashcard_state.dart';
+import '../models/learning_stat.dart';
+import '../models/quiz_stat.dart';
+import '../models/review_queue.dart';
+import '../models/saved_theme_mode.dart';
+import '../models/session_log.dart';
+import '../models/word.dart';
+import 'learning_repository.dart';
+import 'word_repository.dart';
+
+Future<Box<T>> _openBoxWithMigration<T>(
+  String name,
+  HiveAesCipher cipher,
+) async {
+  try {
+    return await Hive.openBox<T>(name, encryptionCipher: cipher);
+  } catch (_) {
+    final box = await Hive.openBox<T>(name);
+    final data = Map<dynamic, T>.from(box.toMap());
+    await box.close();
+    await box.deleteFromDisk();
+    final newBox = await Hive.openBox<T>(name, encryptionCipher: cipher);
+    await newBox.putAll(data);
+    return newBox;
+  }
+}
+
+/// Open all Hive boxes used by the application.
+Future<void> openAllBoxes(HiveAesCipher cipher) async {
+  final tasks = [
+    () => _openBoxWithMigration<Map>(favoritesBoxName, cipher),
+    () => _openBoxWithMigration<HistoryEntry>(historyBoxName, cipher),
+    () => _openBoxWithMigration<QuizStat>(quizStatsBoxName, cipher),
+    () => _openBoxWithMigration<FlashcardState>(flashcardStateBoxName, cipher),
+    () => _openBoxWithMigration<Word>(WordRepository.boxName, cipher),
+    () => _openBoxWithMigration<LearningStat>(LearningRepository.boxName, cipher),
+    () => _openBoxWithMigration<SessionLog>(sessionLogBoxName, cipher),
+    () => _openBoxWithMigration<ReviewQueue>(reviewQueueBoxName, cipher),
+    () => _openBoxWithMigration<SavedThemeMode>(settingsBoxName, cipher),
+  ];
+  for (final task in tasks) {
+    await task();
+  }
+}

--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tango/constants.dart';
+import 'package:tango/history_entry_model.dart';
+import 'package:tango/models/flashcard_state.dart';
+import 'package:tango/models/learning_stat.dart';
+import 'package:tango/models/quiz_stat.dart';
+import 'package:tango/models/review_queue.dart';
+import 'package:tango/models/saved_theme_mode.dart';
+import 'package:tango/models/session_log.dart';
+import 'package:tango/models/word.dart';
+import 'package:tango/services/box_initializer.dart';
+import 'package:tango/services/learning_repository.dart';
+import 'package:tango/services/word_repository.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    final adapters = [
+      HistoryEntryAdapter(),
+      WordAdapter(),
+      LearningStatAdapter(),
+      QuizStatAdapter(),
+      SessionLogAdapter(),
+      ReviewQueueAdapter(),
+      SavedThemeModeAdapter(),
+      FlashcardStateAdapter(),
+    ];
+    for (final adapter in adapters) {
+      if (!Hive.isAdapterRegistered(adapter.typeId)) {
+        Hive.registerAdapter(adapter);
+      }
+    }
+  });
+
+  tearDown(() async {
+    final boxes = [
+      favoritesBoxName,
+      historyBoxName,
+      quizStatsBoxName,
+      flashcardStateBoxName,
+      WordRepository.boxName,
+      LearningRepository.boxName,
+      sessionLogBoxName,
+      reviewQueueBoxName,
+      settingsBoxName,
+    ];
+    for (final name in boxes) {
+      if (await Hive.boxExists(name)) {
+        await Hive.deleteBoxFromDisk(name);
+      }
+    }
+    await dir.delete(recursive: true);
+  });
+
+  test('openAllBoxes opens each required Hive box', () async {
+    final cipher = HiveAesCipher(Hive.generateSecureKey());
+    await openAllBoxes(cipher);
+
+    expect(Hive.isBoxOpen(favoritesBoxName), isTrue);
+    expect(Hive.isBoxOpen(historyBoxName), isTrue);
+    expect(Hive.isBoxOpen(quizStatsBoxName), isTrue);
+    expect(Hive.isBoxOpen(flashcardStateBoxName), isTrue);
+    expect(Hive.isBoxOpen(WordRepository.boxName), isTrue);
+    expect(Hive.isBoxOpen(LearningRepository.boxName), isTrue);
+    expect(Hive.isBoxOpen(sessionLogBoxName), isTrue);
+    expect(Hive.isBoxOpen(reviewQueueBoxName), isTrue);
+    expect(Hive.isBoxOpen(settingsBoxName), isTrue);
+  });
+}


### PR DESCRIPTION
## Why
- repeated box opening logic in `main.dart`

## What
- add a service that opens all Hive boxes with migration
- call the new service from `main`
- unit test that each box opens

## How
- `openAllBoxes` executes the same `_openBoxWithMigration` calls
- tests verify boxes are open after invocation

------
https://chatgpt.com/codex/tasks/task_e_6864e94756d8832aa26425ca6079578e