### PR TITLE
Fix web build adapter type issue

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,7 +52,7 @@ class _InitData {
 Future<_InitData> _initialize() async {
   await Hive.initFlutter();
 
-  final adapters = [
+  final List<TypeAdapter<dynamic>> adapters = [
     HistoryEntryAdapter(),
     WordAdapter(),
     LearningStatAdapter(),


### PR DESCRIPTION
## Summary
- specify adapter list type for Hive registration to compile on Dart 3.4

## Testing
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*
- `flutter format -o none --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f6fbc080832a83bb656cf8db8ae9