### PR TITLE
Fix slow start by concurrent Hive box init

### DIFF
--- a/lib/services/box_initializer.dart
+++ b/lib/services/box_initializer.dart
@@ -32,17 +32,15 @@ Future<Box<T>> _openBoxWithMigration<T>(
 /// Open all Hive boxes used by the application.
 Future<void> openAllBoxes(HiveAesCipher cipher) async {
   final tasks = [
-    () => _openBoxWithMigration<Map>(favoritesBoxName, cipher),
-    () => _openBoxWithMigration<HistoryEntry>(historyBoxName, cipher),
-    () => _openBoxWithMigration<QuizStat>(quizStatsBoxName, cipher),
-    () => _openBoxWithMigration<FlashcardState>(flashcardStateBoxName, cipher),
-    () => _openBoxWithMigration<Word>(WordRepository.boxName, cipher),
-    () => _openBoxWithMigration<LearningStat>(LearningRepository.boxName, cipher),
-    () => _openBoxWithMigration<SessionLog>(sessionLogBoxName, cipher),
-    () => _openBoxWithMigration<ReviewQueue>(reviewQueueBoxName, cipher),
-    () => _openBoxWithMigration<SavedThemeMode>(settingsBoxName, cipher),
+    _openBoxWithMigration<Map>(favoritesBoxName, cipher),
+    _openBoxWithMigration<HistoryEntry>(historyBoxName, cipher),
+    _openBoxWithMigration<QuizStat>(quizStatsBoxName, cipher),
+    _openBoxWithMigration<FlashcardState>(flashcardStateBoxName, cipher),
+    _openBoxWithMigration<Word>(WordRepository.boxName, cipher),
+    _openBoxWithMigration<LearningStat>(LearningRepository.boxName, cipher),
+    _openBoxWithMigration<SessionLog>(sessionLogBoxName, cipher),
+    _openBoxWithMigration<ReviewQueue>(reviewQueueBoxName, cipher),
+    _openBoxWithMigration<SavedThemeMode>(settingsBoxName, cipher),
   ];
-  for (final task in tasks) {
-    await task();
-  }
+  await Future.wait(tasks);
 }


### PR DESCRIPTION
## Why
- app startup took long and sometimes home/word list screens wouldn't appear
- opening Hive boxes sequentially blocked initialization

## What
- open all Hive boxes in parallel using `Future.wait`

## How
- modify `openAllBoxes` in `box_initializer.dart`

- [ ] code formatted


------
https://chatgpt.com/codex/tasks/task_e_6865208826f0832a8c92ba3d29ce6308