### PR TITLE
Fix word list loading

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,6 +76,7 @@ Future<_InitData> _initialize() async {
   final theme = ThemeProvider();
   await theme.loadAppPreferences();
   final repo = await FlashcardRepository.open();
+  await repo.loadAll();
   return _InitData(theme: theme, repo: repo);
 }
 


### PR DESCRIPTION
## Why
Users reported the word list screen shows no words even though data exists.

## What
- preload flashcards during app initialization so words are available immediately

## How
- call `FlashcardRepository.loadAll()` inside `_initialize()`

- [ ] `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686523ba0f58832a911e0434a4fca760