### PR TITLE
docs: add web build troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ dart run build_runner build --delete-conflicting-outputs
 
 flutter run -d chrome もしくはシミュレータ。
 
+### Web ビルドで画面が表示されないとき
+ブラウザに旧バージョンの `flutter.js` や Service Worker が残っていると、ビルド後に画面がスピナー状態のまま止まることがあります。以下を試してください。
+
+1. `flutter clean` を実行してから `flutter build web --pwa-strategy=none` を実行する
+2. Chrome DevTools の **Application > Service Workers** で登録済みワーカーとキャッシュを削除
+3. それでも解決しない場合はブラウザのキャッシュをクリアして再読み込み
+
+CI でも `--pwa-strategy=none` を使用しているため、ローカルビルドでもこのオプションを付けるとキャッシュ問題を避けられます。
+
 9. コーディングガイドライン
 
 flutter_lints 3 に準拠。


### PR DESCRIPTION
## Summary
- document how to clear caches when the web build stays stuck on the spinner

## Testing
- `dart format README.md --set-exit-if-changed` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653260e798832a932f646157087a91