### PR TITLE
Implement slider overlay for WordbookScreen

### DIFF
--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -91,20 +91,51 @@ void main() {
     expect(find.byIcon(Icons.chevron_right), findsOneWidget);
   });
 
-  testWidgets('shows nav arrows on narrow screen', (tester) async {
+  testWidgets('edge taps navigate pages', (tester) async {
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
     final prefs = await SharedPreferences.getInstance();
+    final key = GlobalKey<WordbookScreenState>();
     await tester.pumpWidget(MediaQuery(
       data: const MediaQueryData(size: Size(320, 600)),
       child: MaterialApp(
         home: WordbookScreen(
+          key: key,
           flashcards: cards,
           prefsProvider: () async => prefs,
         ),
       ),
     ));
     await tester.pumpAndSettle();
-    expect(find.byIcon(Icons.chevron_left), findsOneWidget);
-    expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    expect(key.currentState!.currentIndex, 0);
+    await tester.tapAt(const Offset(310, 300));
+    await tester.pumpAndSettle();
+    expect(key.currentState!.currentIndex, 1);
+    await tester.tapAt(const Offset(10, 300));
+    await tester.pumpAndSettle();
+    expect(key.currentState!.currentIndex, 0);
+  });
+
+  testWidgets('center tap toggles slider and slider changes page', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    final prefs = await SharedPreferences.getInstance();
+    final key = GlobalKey<WordbookScreenState>();
+    await tester.pumpWidget(MediaQuery(
+      data: const MediaQueryData(size: Size(320, 600)),
+      child: MaterialApp(
+        home: WordbookScreen(
+          key: key,
+          flashcards: cards,
+          prefsProvider: () async => prefs,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(Slider), findsNothing);
+    await tester.tapAt(const Offset(160, 300));
+    await tester.pumpAndSettle();
+    expect(find.byType(Slider), findsOneWidget);
+    await tester.drag(find.byType(Slider), const Offset(100, 0));
+    await tester.pumpAndSettle();
+    expect(key.currentState!.currentIndex, 1);
   });
 }


### PR DESCRIPTION
## Why
- navigating by tapping screen edges was requested
- need a slider to jump directly to a page

## What
- manage slider visibility and value in `WordbookScreenState`
- overlay gesture areas for previous/next and centre tap
- show an animated slider at the bottom
- new widget tests for edge taps and slider behaviour

## How
- add `_showSlider`, `_sliderValue` and timer logic
- update build method with gesture detectors and slider
- expand tests to cover new interactions

------
https://chatgpt.com/codex/tasks/task_e_68653702f7ac832aa505eb81133b42f8