### PR TITLE
Integrate MangaWordViewer with route transition

### DIFF
--- a/lib/wordbook_window.dart
+++ b/lib/wordbook_window.dart
@@ -9,13 +9,19 @@ Future<void> showMangaWordViewer(
   required List<Flashcard> words,
   required int initialIndex,
 }) {
-  return showGeneralDialog(
-    context: context,
-    barrierColor: Colors.black54,
-    barrierDismissible: true,
-    pageBuilder: (context, _, __) => MangaWordViewer(
-      words: words,
-      initialIndex: initialIndex,
+  return Navigator.of(context).push(
+    PageRouteBuilder(
+      opaque: false,
+      barrierDismissible: true,
+      barrierColor: Colors.black54,
+      pageBuilder: (context, animation, secondaryAnimation) =>
+          MangaWordViewer(
+        words: words,
+        initialIndex: initialIndex,
+      ),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        return FadeTransition(opacity: animation, child: child);
+      },
     ),
   );
 }


### PR DESCRIPTION
## Summary
- open `MangaWordViewer` via `PageRouteBuilder` for a fade transition

## Testing
- `dart format lib/wordbook_window.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f069f444832a940223c9fbea8d7c