### PR TITLE
feat: open wordbook viewer from bottom nav

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -29,6 +29,8 @@ import 'flashcard_repository_provider.dart';
 import 'navigation_helper.dart';
 import 'utils/main_screen_utils.dart';
 import 'main_screen/main_navigation_bar.dart';
+import 'models/word.dart';
+import 'manga_word_viewer.dart';
 
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -47,6 +49,27 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       GlobalKey<WordbookScreenState>();
   int _wordbookIndex = 0;
   ReviewMode _reviewMode = ReviewMode.random;
+
+  /// Convert [Flashcard] to [Word] for MangaWordViewer.
+  Word _toWord(Flashcard fc) {
+    return Word(
+      id: fc.id,
+      term: fc.term,
+      reading: fc.reading,
+      description: fc.description,
+      relatedIds: fc.relatedIds,
+      tags: fc.tags,
+      examExample: fc.examExample,
+      examPoint: fc.examPoint,
+      practicalTip: fc.practicalTip,
+      categoryLarge: fc.categoryLarge,
+      categoryMedium: fc.categoryMedium,
+      categorySmall: fc.categorySmall,
+      categoryItem: fc.categoryItem,
+      importance: fc.importance,
+      english: fc.english,
+    );
+  }
 
 
   Widget _buildCurrentScreenContent() {
@@ -102,13 +125,17 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       return;
     }
     if (index == 2) {
-      ref.read(flashcardRepositoryProvider).loadAll().then((list) {
+      // Load words and show MangaWordViewer as a modal screen.
+      ref.read(flashcardRepositoryProvider).loadAll().then((cards) {
         if (!mounted) return;
-        setState(() {
-          _bottomNavIndex = index;
-          _currentScreen = AppScreen.wordbook;
-          _currentArguments = ScreenArguments(flashcards: list);
-        });
+        final wordList = cards.map(_toWord).toList();
+        Navigator.of(context).push(
+          PageRouteBuilder(
+            opaque: false,
+            pageBuilder: (_, __, ___) =>
+                MangaWordViewer(words: wordList, initialIndex: 0),
+          ),
+        );
       });
       return;
     }

--- a/lib/manga_word_viewer.dart
+++ b/lib/manga_word_viewer.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import 'models/word.dart';
+
+/// Simple viewer showing [Word] details in a full-screen pager.
+class MangaWordViewer extends StatefulWidget {
+  final List<Word> words;
+  final int initialIndex;
+
+  const MangaWordViewer({
+    Key? key,
+    required this.words,
+    this.initialIndex = 0,
+  }) : super(key: key);
+
+  @override
+  State<MangaWordViewer> createState() => _MangaWordViewerState();
+}
+
+class _MangaWordViewerState extends State<MangaWordViewer> {
+  late final PageController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PageController(initialPage: widget.initialIndex);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black.withOpacity(0.8),
+      body: SafeArea(
+        child: PageView.builder(
+          controller: _controller,
+          itemCount: widget.words.length,
+          itemBuilder: (context, index) {
+            final word = widget.words[index];
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      word.term,
+                      style: const TextStyle(
+                        fontSize: 28,
+                        color: Colors.white,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      word.description,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        color: Colors.white,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `MangaWordViewer` widget
- launch viewer as full screen when tapping Wordbook tab
- keep other tab behaviour the same

## Testing
- `dart format --set-exit-if-changed .` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_686615f3db50832a8ebb5c55ba49cf99