### PR TITLE
Add WordDeck model

### DIFF
--- a/lib/models/word_deck.dart
+++ b/lib/models/word_deck.dart
@@ -1,0 +1,11 @@
+import 'word.dart';
+
+class WordDeck {
+  final String title;
+  final List<Word> words;
+
+  WordDeck({
+    required this.title,
+    required this.words,
+  });
+}


### PR DESCRIPTION
## Why
Needed a container for grouping `Word` objects.

## What
- create `lib/models/word_deck.dart`

## How
- added `WordDeck` class with title and words list
- attempted to run `dart format` *(fails in Codex)*

- [ ] Code formatted

------
https://chatgpt.com/codex/tasks/task_e_686744f1a184832a8d90a1fa299bfcf9