### PR TITLE
Add WordbookLibraryPage

### DIFF
--- a/lib/screens/wordbook_library_page.dart
+++ b/lib/screens/wordbook_library_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../models/word_deck.dart';
+import '../widgets/word_deck_card.dart';
+import 'manga_word_viewer.dart';
+
+class WordbookLibraryPage extends StatelessWidget {
+  final List<WordDeck> decks;
+
+  const WordbookLibraryPage({super.key, required this.decks});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('単語帳ライブラリ')),
+      body: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+        ),
+        itemCount: decks.length,
+        itemBuilder: (context, index) {
+          final deck = decks[index];
+          return WordDeckCard(
+            deck: deck,
+            onTap: () {
+              Navigator.of(context).push(
+                PageRouteBuilder(
+                  fullscreenDialog: true,
+                  pageBuilder: (_, __, ___) => MangaWordViewer(
+                    words: deck.words,
+                    initialIndex: 0,
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Why
- need a page to list word decks and open them in viewer

## What
- create `WordbookLibraryPage` for showing decks in a grid
- open `MangaWordViewer` as a fullscreen dialog on tap

## How
- added `lib/screens/wordbook_library_page.dart`

Checklist:
- [ ] `dart format`

------
https://chatgpt.com/codex/tasks/task_e_6867d8c9c488832a89d3fc5c945d824a