### PR TITLE
Fix web build imports and add deck widgets

### DIFF
--- a/lib/models/word_deck.dart
+++ b/lib/models/word_deck.dart
@@ -1,0 +1,13 @@
+import 'word.dart';
+
+/// A container for a set of related words shown in the wordbook library.
+
+class WordDeck {
+  final String title;
+  final List<Word> words;
+
+  WordDeck({
+    required this.title,
+    required this.words,
+  });
+}

--- a/lib/screens/wordbook_library_page.dart
+++ b/lib/screens/wordbook_library_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../models/word_deck.dart';
+import '../widgets/word_deck_card.dart';
+import '../manga_word_viewer.dart';
+
+class WordbookLibraryPage extends StatelessWidget {
+  final List<WordDeck> decks;
+
+  const WordbookLibraryPage({super.key, required this.decks});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('単語帳ライブラリ')),
+      body: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+        ),
+        itemCount: decks.length,
+        itemBuilder: (context, index) {
+          final deck = decks[index];
+          return WordDeckCard(
+            deck: deck,
+            onTap: () {
+              Navigator.of(context).push(
+                PageRouteBuilder(
+                  fullscreenDialog: true,
+                  pageBuilder: (_, __, ___) => MangaWordViewer(
+                    words: deck.words,
+                    initialIndex: 0,
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/word_deck_card.dart
+++ b/lib/widgets/word_deck_card.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import '../models/word_deck.dart';
+
+class WordDeckCard extends StatelessWidget {
+  final WordDeck deck;
+  final VoidCallback onTap;
+
+  const WordDeckCard({
+    super.key,
+    required this.deck,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.library_books,
+              size: 40,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              deck.title,
+              textAlign: TextAlign.center,
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            Text('${deck.words.length}語'),
+          ],
+        ),
+      ),
+    );
+
+    return Center(
+      child: InkWell(
+        onTap: onTap,
+        child: card,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- ensure wordbook library screen imports MangaWordViewer with a relative path
- add WordDeck model to group word lists
- show each deck using WordDeckCard
- document WordDeck class

## Testing
- `dart format --set-exit-if-changed lib/models/word_deck.dart lib/widgets/word_deck_card.dart lib/screens/wordbook_library_page.dart` *(fails: dart command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687b3b201c832a8e4154b2d039ae84