### PR TITLE
Fix wordbook library opening showing summary

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -126,18 +126,6 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       return;
     }
     if (index == 2) {
-      // Load words and show MangaWordViewer as a modal screen.
-      ref.read(flashcardRepositoryProvider).loadAll().then((cards) {
-        if (!mounted) return;
-        final wordList = cards.map(_toWord).toList();
-        Navigator.of(context).push(
-          PageRouteBuilder(
-            opaque: false,
-            pageBuilder: (_, __, ___) =>
-                MangaWordViewer(words: wordList, initialIndex: 0),
-          ),
-        );
-      });
       Navigator.of(context).push(
         MaterialPageRoute(
           builder: (_) => WordbookLibraryPage(decks: yourDeckList),


### PR DESCRIPTION
## Summary
- remove MangaWordViewer auto-launch when opening the wordbook library

## Testing
- `dart format --set-exit-if-changed lib/main_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691ee5582c832ab386b2f169594937