### PR TITLE
Load all flashcards as a single wordbook

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -118,6 +118,17 @@ class _MainScreenState extends ConsumerState<MainScreen> {
     }
   }
 
+  Future<void> _openWordbookLibrary() async {
+    final repo = ref.read(flashcardRepositoryProvider);
+    final decks = await loadDefaultDecks(repo);
+    if (!mounted) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => WordbookLibraryPage(decks: decks),
+      ),
+    );
+  }
+
   void _onBottomNavItemTapped(int index) {
     if (_bottomNavIndex == index &&
         _currentScreen == appScreenFromIndex(index) &&
@@ -126,11 +137,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       return;
     }
     if (index == 2) {
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => WordbookLibraryPage(decks: yourDeckList),
-        ),
-      );
+      _openWordbookLibrary();
       return;
     }
     setState(() {

--- a/lib/sample_decks.dart
+++ b/lib/sample_decks.dart
@@ -1,46 +1,31 @@
+import 'flashcard_model.dart';
+import 'flashcard_repository.dart';
 import 'models/word.dart';
 import 'models/word_deck.dart';
 
-final Word _word1 = Word(
-  id: 'SG001',
-  term: '情報セキュリティの概念',
-  reading: 'じょうほうせきゅりてぃのがいねん',
-  description: '情報資産を守るための取り組み全般。',
-  categoryLarge: '技術要素',
-  categoryMedium: 'セキュリティ',
-  categorySmall: '情報セキュリティ 情報セキュリティの目的と考え方',
-  categoryItem: '情報セキュリティの目的と考え方',
-  importance: 5,
-  english: 'ー',
-);
+Word _toWord(Flashcard fc) {
+  return Word(
+    id: fc.id,
+    term: fc.term,
+    reading: fc.reading,
+    description: fc.description,
+    relatedIds: fc.relatedIds,
+    tags: fc.tags,
+    examExample: fc.examExample,
+    examPoint: fc.examPoint,
+    practicalTip: fc.practicalTip,
+    categoryLarge: fc.categoryLarge,
+    categoryMedium: fc.categoryMedium,
+    categorySmall: fc.categorySmall,
+    categoryItem: fc.categoryItem,
+    importance: fc.importance,
+    english: fc.english,
+  );
+}
 
-final Word _word2 = Word(
-  id: 'SG002',
-  term: '機密性',
-  english: 'Confidentiality',
-  reading: 'きみつせい',
-  description: '情報を許可された者だけが利用できる状態に保つこと。',
-  categoryLarge: '技術要素',
-  categoryMedium: 'セキュリティ',
-  categorySmall: '情報セキュリティ 情報セキュリティの目的と考え方',
-  categoryItem: '情報セキュリティの目的と考え方',
-  importance: 5,
-);
-
-final Word _word3 = Word(
-  id: 'SG003',
-  term: '完全性',
-  english: 'Integrity',
-  reading: 'かんぜんせい',
-  description: '情報が改ざんされていない状態を保つこと。',
-  categoryLarge: '技術要素',
-  categoryMedium: 'セキュリティ',
-  categorySmall: '情報セキュリティ 情報セキュリティの目的と考え方',
-  categoryItem: '情報セキュリティの目的と考え方',
-  importance: 5,
-);
-
-final List<WordDeck> yourDeckList = [
-  WordDeck(title: 'セキュリティ入門', words: [_word1, _word2, _word3]),
-  WordDeck(title: '機密性と完全性', words: [_word2, _word3]),
-];
+/// Load the default word decks from the bundled JSON.
+Future<List<WordDeck>> loadDefaultDecks(FlashcardRepository repo) async {
+  final cards = await repo.loadAll();
+  final words = cards.map(_toWord).toList();
+  return [WordDeck(title: '全単語帳', words: words)];
+}


### PR DESCRIPTION
## Summary
- build wordbook library from `words.json`
- drop hard-coded sample decks

## Testing
- `dart format lib/sample_decks.dart lib/main_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692338751c832aa55d3925e4ae2966