### PR TITLE
Fix wordbook library detail view

### DIFF
--- a/lib/models/word.dart
+++ b/lib/models/word.dart
@@ -96,3 +96,26 @@ class Word extends HiveObject {
     };
   }
 }
+
+extension WordMapper on Word {
+  /// Convert this [Word] to a [Flashcard] for reuse in existing screens.
+  Flashcard toFlashcard() {
+    return Flashcard(
+      id: id,
+      term: term,
+      english: english,
+      reading: reading,
+      description: description,
+      relatedIds: relatedIds,
+      tags: tags,
+      examExample: examExample,
+      examPoint: examPoint,
+      practicalTip: practicalTip,
+      categoryLarge: categoryLarge,
+      categoryMedium: categoryMedium,
+      categorySmall: categorySmall,
+      categoryItem: categoryItem,
+      importance: importance,
+    );
+  }
+}

--- a/lib/screens/wordbook_library_page.dart
+++ b/lib/screens/wordbook_library_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../models/word_deck.dart';
 import '../widgets/word_deck_card.dart';
-import '../manga_word_viewer.dart';
-import 'manga_word_viewer.dart';
+import '../wordbook_screen.dart';
+import '../models/word.dart';
 
 class WordbookLibraryPage extends StatelessWidget {
   final List<WordDeck> decks;
@@ -24,13 +24,10 @@ class WordbookLibraryPage extends StatelessWidget {
           return WordDeckCard(
             deck: deck,
             onTap: () {
+              final flashcards = deck.words.map((w) => w.toFlashcard()).toList();
               Navigator.of(context).push(
-                PageRouteBuilder(
-                  fullscreenDialog: true,
-                  pageBuilder: (_, __, ___) => MangaWordViewer(
-                    words: deck.words,
-                    initialIndex: 0,
-                  ),
+                MaterialPageRoute(
+                  builder: (_) => WordbookScreen(flashcards: flashcards),
                 ),
               );
             },


### PR DESCRIPTION
## Summary
- convert `Word` to `Flashcard` for reuse
- open `WordbookScreen` when selecting a deck so the detail view matches the normal word detail

## Testing
- `dart format lib/models/word.dart lib/screens/wordbook_library_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0166aae4832a8450236fad2e66ae