### PR TITLE
Add overlay controls to wordbook

### DIFF
--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -107,4 +107,51 @@ void main() {
     expect(find.byIcon(Icons.chevron_left), findsOneWidget);
     expect(find.byIcon(Icons.chevron_right), findsOneWidget);
   });
+
+  testWidgets('tap toggles page controls', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+      home: WordbookScreen(
+        flashcards: cards,
+        prefsProvider: () async => prefs,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Slider), findsNothing);
+
+    await tester.tap(find.byType(PageView));
+    await tester.pumpAndSettle();
+    expect(find.byType(Slider), findsOneWidget);
+
+    await tester.tap(find.byType(PageView));
+    await tester.pumpAndSettle();
+    expect(find.byType(Slider), findsNothing);
+  });
+
+  testWidgets('slider changes page and saves bookmark', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+      home: WordbookScreen(
+        flashcards: cards,
+        prefsProvider: () async => prefs,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PageView));
+    await tester.pumpAndSettle();
+
+    final sliderFinder = find.byType(Slider);
+    final start = tester.getTopLeft(sliderFinder);
+    final end = tester.getTopRight(sliderFinder);
+    final y = (start.dy + end.dy) / 2;
+    await tester.tapAt(Offset(end.dx - 1, y));
+    await tester.pumpAndSettle();
+
+    expect(find.text('(2 / 2)'), findsOneWidget);
+    expect(prefs.getInt('bookmark_pageIndex'), 1);
+  });
 }


### PR DESCRIPTION
## Summary
- allow toggling control overlay in `WordbookScreen`
- use `GestureDetector` to show controls on tap
- provide slider and close button overlay when controls are visible
- expand wordbook screen tests to cover overlay behavior

## Testing
- `dart format lib/wordbook_screen.dart test/wordbook_screen_test.dart` *(fails: command not found)*
- `flutter format lib/wordbook_screen.dart test/wordbook_screen_test.dart` *(fails: command not found)*
- `dart run test/test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b4ba28a1c832a9f1c356c5b1495b1