### PR TITLE
fix: make word detail text follow theme

### DIFF
--- a/lib/widgets/detail_item.dart
+++ b/lib/widgets/detail_item.dart
@@ -44,8 +44,7 @@ class DetailItem extends StatelessWidget {
                   color: Theme.of(context)
                       .textTheme
                       .bodyLarge
-                      ?.color
-                      ?.withOpacity(0.85),
+                      ?.color,
                 ),
           ),
         ],

--- a/lib/widgets/word_detail/flashcard_detail_view.dart
+++ b/lib/widgets/word_detail/flashcard_detail_view.dart
@@ -87,8 +87,7 @@ class FlashcardDetailView extends StatelessWidget {
                     color: Theme.of(context)
                         .textTheme
                         .bodyMedium
-                        ?.color
-                        ?.withOpacity(0.7),
+                        ?.color,
                   ),
             ),
           const SizedBox(height: 12),

--- a/lib/word_detail_screen.dart
+++ b/lib/word_detail_screen.dart
@@ -141,8 +141,7 @@ class _WordDetailScreenState extends State<WordDetailScreen> {
                       color: Theme.of(context)
                           .textTheme
                           .bodyMedium
-                          ?.color
-                          ?.withOpacity(0.7),
+                          ?.color,
                     ),
               ),
             SizedBox(height: 12),


### PR DESCRIPTION
## Why
- word details in WordbookScreen used low-opacity text, making it hard to read

## What
- remove fixed opacity on detail item values
- remove opacity on reading text in flashcard views and word detail screen

## How
- updated `DetailItem`, `FlashcardDetailView`, and `WordDetailScreen` to use the theme's body color directly



------
https://chatgpt.com/codex/tasks/task_e_686b50dd5110832a9dc9d0f4fe4b040e