### PR TITLE
Fix WordbookScreen theming

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -92,8 +92,10 @@ class WordbookScreenState extends State<WordbookScreen> {
   Widget build(BuildContext context) {
     final isTabletOrDesktop =
         MediaQuery.of(context).size.shortestSide >= kTabletBreakpoint;
-    return Stack(
-      children: [
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: Stack(
+        children: [
         GestureDetector(
           onTapUp: (details) {
             final size = context.size;
@@ -211,6 +213,7 @@ class WordbookScreenState extends State<WordbookScreen> {
           ),
         ],
       ],
+    ),
     );
   }
 }


### PR DESCRIPTION
## Why
WordbookScreen lacked a Scaffold wrapper so theme background colors were not applied. This caused overlapping screens and inconsistent light/dark mode behavior.

## What
- Wrap WordbookScreen with `Scaffold` and apply `scaffoldBackgroundColor`

## How
- Updated `build` method in `lib/wordbook_screen.dart`

- [ ] Code formatted (dart format failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_686b59f0007c832a8aa97f7a410fc9df