### PR TITLE
Highlight wordbook controls and disable edge taps

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -125,7 +125,7 @@ class WordbookScreenState extends State<WordbookScreen> {
           ),
         ),
         // Tappable areas for page navigation on phones
-        if (widget.flashcards.length > 1) ...[
+        if (widget.flashcards.length > 1 && !_showControls) ...[
           const Positioned(
             left: 0,
             top: 0,
@@ -174,11 +174,18 @@ class WordbookScreenState extends State<WordbookScreen> {
         if (_showControls) ...[
           Positioned(
             top: 0,
+            left: 0,
             right: 0,
-            child: SafeArea(
-              child: IconButton(
-                icon: const Icon(Icons.close),
-                onPressed: () => Navigator.of(context).pop(),
+            child: Container(
+              color: Colors.black54,
+              child: SafeArea(
+                child: Align(
+                  alignment: Alignment.topRight,
+                  child: IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ),
               ),
             ),
           ),
@@ -186,10 +193,12 @@ class WordbookScreenState extends State<WordbookScreen> {
             bottom: 0,
             left: 0,
             right: 0,
-            child: SafeArea(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
+            child: Container(
+              color: Colors.black54,
+              child: SafeArea(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
                   Slider(
                     value: (_currentIndex + 1).toDouble(),
                     min: 1,


### PR DESCRIPTION
## Why
- wordbook controls should stand out when visible
- avoid interfering with edge tap navigation while controls are open

## What
- add dark overlay containers above and below the flashcards when controls are shown
- hide edge tap areas when controls are visible

## How
- wrap close button and slider inside `Container(color: Colors.black54)`
- apply `_showControls` condition on `_EdgeTapArea`

### Checklist
- [ ] `dart format` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba38f98b4832a84e97f86924b4a23