### PR TITLE
Fix Riverpod override issue in study_session_flow_test

### DIFF
--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -21,7 +21,7 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    final adapters = [
+    final List<TypeAdapter<dynamic>> adapters = [
       HistoryEntryAdapter(),
       WordAdapter(),
       LearningStatAdapter(),

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -52,12 +52,6 @@ void main() {
             return StudySessionController(logBox, ReviewQueueService(queueBox));
           })
         ],
-        child: const MaterialApp(home: Scaffold()),
-      ),
-    );
-
-    await tester.pumpWidget(
-      ProviderScope(
         child: MaterialApp(
           home: Builder(
             builder: (context) {


### PR DESCRIPTION
## Why
- `flutter test` failed due to changing Provider overrides between pumps
- adapter list in `box_initializer_test.dart` inferred as `List<Object>`

## What
- combine `ProviderScope` setup into single `pumpWidget`
- type adapters list as `List<TypeAdapter<dynamic>>`

## How
- formatted with `dart format` *(failed: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc46427fc832ab3a53fb8afeb39a2