### PR TITLE
fix: add search button in wordbook

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -185,10 +185,19 @@ class WordbookScreenState extends State<WordbookScreen> {
                   Container(
                     color: Colors.black54,
                     padding: const EdgeInsets.only(top: 40, left: 16, right: 16),
-                    alignment: Alignment.centerRight,
-                    child: IconButton(
-                      icon: const Icon(Icons.close, color: Colors.white),
-                      onPressed: () => Navigator.of(context).pop(),
+                    alignment: Alignment.centerLeft,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.close, color: Colors.white),
+                          onPressed: () => Navigator.of(context).pop(),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.search, color: Colors.white),
+                          onPressed: _openSearch,
+                        ),
+                      ],
                     ),
                   ),
                   Expanded(child: Container(color: Colors.transparent)),


### PR DESCRIPTION
## Why
- the wordbook menu needed a search entry alongside the close button

## What
- switched top control alignment to `Alignment.centerLeft`
- added a search button that triggers `_openSearch()`
- laid out close/search buttons with `Row` and `MainAxisAlignment.spaceBetween`

## How
- updated `lib/wordbook_screen.dart`
- attempted to run `dart format lib/wordbook_screen.dart` but the `dart` command was unavailable

------
https://chatgpt.com/codex/tasks/task_e_686c4fbc839c832aab0e9f92b7f99173