### PR TITLE
Fix search sheet web build error

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'flashcard_model.dart';


### PR DESCRIPTION
## Why
Web build failed due to missing import for `FilteringTextInputFormatter`.

## What
- add `package:flutter/services.dart` import in `wordbook_screen.dart`

## How
- `dart format --set-exit-if-changed .` *(failed: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6582ca00832aaebe6278ef56aac8