### PR TITLE
fix: restrict search input

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -361,6 +361,11 @@ class _SearchSheetState extends State<_SearchSheet> {
                       labelText: '検索',
                       prefixIcon: Icon(Icons.search),
                     ),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.deny(
+                        RegExp(r'[<>/\\]'),
+                      ),
+                    ],
                     onChanged: (v) => setState(() => _query = v),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- restrict invalid characters in search field using `FilteringTextInputFormatter`

## Testing
- `dart format --set-exit-if-changed lib/wordbook_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c7532563c832aa7b8165543a7739f