### PR TITLE
Fix missing import causing compile error

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'flashcard_model.dart';


### PR DESCRIPTION
## Summary
- fix wordbook search field by importing `flutter/services.dart`

## Testing
- `dart format --output none --set-exit-if-changed lib/wordbook_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c95697f48832aa8b391cdcccca9f9