### PR TITLE
Fix Wordbook menu closing

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -217,6 +217,13 @@ class WordbookScreenState extends State<WordbookScreen> {
             ),
           ),
         if (_showControls) ...[
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _toggleControls,
+              child: const SizedBox.expand(),
+            ),
+          ),
           Positioned(
             top: 0,
             left: 0,


### PR DESCRIPTION
## Why
Menu overlays on the Wordbook screen couldn't be dismissed easily.

## What
- allow tapping outside the controls to close them

## How
- added transparent full-screen `GestureDetector` when controls are visible

Checklist:
- [ ] Code formatted


------
https://chatgpt.com/codex/tasks/task_e_686c9aea0a94832a8541761d83b397c9