### PR TITLE
fix test setup isolation

### DIFF
--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -23,7 +23,7 @@ void main() {
   late Box<LearningStat> statBox;
   late Box<ReviewQueue> queueBox;
 
-  setUpAll(() async {
+  setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
     Hive.registerAdapter(SessionLogAdapter());
@@ -34,7 +34,7 @@ void main() {
     queueBox = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
   });
 
-  tearDownAll(() async {
+  tearDown(() async {
     await logBox.close();
     await statBox.close();
     await queueBox.close();


### PR DESCRIPTION
## Why
CI failed loading `study_session_flow_test.dart` because box setup logic ran once for all tests, leaving artifacts behind.

## What
- use `setUp`/`tearDown` instead of `setUpAll`/`tearDownAll`

## How
- `dart format` not run (dart unavailable)


------
https://chatgpt.com/codex/tasks/task_e_686ca4041da8832a81e1795252e21974