### PR TITLE
Fix test compile errors

### DIFF
--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -21,7 +21,7 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    final adapters = [
+    final List<TypeAdapter<dynamic>> adapters = [
       HistoryEntryAdapter(),
       WordAdapter(),
       LearningStatAdapter(),

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -17,6 +17,14 @@ import 'package:tango/flashcard_repository_provider.dart';
 import 'package:tango/study_session_controller.dart';
 import 'package:tango/study_start_sheet.dart';
 
+class _FakeLoader implements FlashcardLoader {
+  final List<Flashcard> cards;
+  _FakeLoader(this.cards);
+
+  @override
+  Future<List<Flashcard>> loadAll() async => cards;
+}
+
 void main() {
   late Directory dir;
   late Box<SessionLog> logBox;
@@ -56,13 +64,6 @@ void main() {
         importance: 1,
       );
 
-  class _FakeLoader implements FlashcardLoader {
-    final List<Flashcard> cards;
-    _FakeLoader(this.cards);
-
-    @override
-    Future<List<Flashcard>> loadAll() async => cards;
-  }
 
   testWidgets('flow one word', (tester) async {
     final words = [_card('1')];


### PR DESCRIPTION
## Why
- CI failed due to syntax errors in test helpers.

## What
- move `_FakeLoader` to top level in `study_session_flow_test.dart`
- type `adapters` list in `box_initializer_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_686ca5fa41cc832aa6a041b5be370037