### PR TITLE
Fix broken WordbookScreen layout

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -95,18 +95,11 @@ class WordbookScreenState extends State<WordbookScreen> {
     final isTabletOrDesktop =
         MediaQuery.of(context).size.shortestSide >= kTabletBreakpoint;
 
-    final bgColor = Theme.of(context).colorScheme.background;
-    return ColoredBox(
-      color: bgColor,
-      child: Stack(
-        children: [
-          PageView.builder(
-
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Stack(
         children: [
-        GestureDetector(
+          GestureDetector(
           onTapUp: (details) {
             final size = context.size;
             if (size != null &&


### PR DESCRIPTION
## Why
Merged code left duplicated widgets in `WordbookScreen`, causing build failures.

## What
- clean up merge artifacts and keep Scaffold-based layout
- include search sheet improvements with close button and input filter

## How
- restored single `Scaffold` implementation
- updated search sheet to use `Container` and added background tap handler

Checklist:
- [ ] Code formatted (dart format unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_686ca87805ec832aa590cfc6893c49e5