### PR TITLE
Fix Wordbook screen overlay

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -201,7 +201,13 @@ class WordbookScreenState extends State<WordbookScreen> {
                       ],
                     ),
                   ),
-                  Expanded(child: Container(color: Colors.transparent)),
+                  Expanded(
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: _toggleControls,
+                      child: Container(color: Colors.transparent),
+                    ),
+                  ),
                   Container(
                     color: Colors.black54,
                     padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Why
Menu overlay could not be closed once opened.

## What
- detect taps on transparent area of overlay to hide controls.

## How
- wrap middle `Expanded` section in `GestureDetector` with `onTap` calling `_toggleControls`.

## Checklist
- [ ] `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ce15f48832a89b26f9911ec2a45