### PR TITLE
Fix slider index sync on related word navigation

### DIFF
--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -15,6 +15,7 @@ class WordDetailContent extends ConsumerStatefulWidget {
   final int initialIndex;
   final WordDetailController? controller;
   final bool showNavigation;
+  final ValueChanged<Flashcard>? onWordChanged;
 
   const WordDetailContent({
     super.key,
@@ -22,6 +23,7 @@ class WordDetailContent extends ConsumerStatefulWidget {
     required this.initialIndex,
     this.controller,
     this.showNavigation = true,
+    this.onWordChanged,
   });
 
   @override
@@ -74,6 +76,7 @@ class _WordDetailContentState extends ConsumerState<WordDetailContent> {
     });
     _loadFavoriteStatus();
     widget.controller?.update();
+    widget.onWordChanged?.call(_historyController.currentFlashcard);
   }
 
   void _loadFavoriteStatus() {

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -63,6 +63,15 @@ class WordbookScreenState extends State<WordbookScreen> {
     await prefs.setInt(_bookmarkKey, index);
   }
 
+  void _onWordChanged(Flashcard card) {
+    final index = widget.flashcards.indexWhere((c) => c.id == card.id);
+    if (index == -1) return;
+    _pageController.jumpToPage(index);
+    setState(() => _currentIndex = index);
+    _saveBookmark(index);
+    widget.onIndexChanged?.call(index);
+  }
+
   Future<void> _openSearch() async {
     final result = await showModalBottomSheet<int>(
       context: context,
@@ -124,6 +133,7 @@ class WordbookScreenState extends State<WordbookScreen> {
                 flashcards: [widget.flashcards[index]],
                 initialIndex: 0,
                 showNavigation: false,
+                onWordChanged: _onWordChanged,
               );
             },
           ),


### PR DESCRIPTION
## Why
Related word navigation inside `WordbookScreen` didn't update the slider position, confusing users.

## What
- added `onWordChanged` callback to `WordDetailContent`
- updated `WordbookScreen` to jump to the proper page when another word is selected via related terms

## How
- introduced `_onWordChanged` in `WordbookScreenState`
- passed callback to `WordDetailContent`

- [ ] Code formatted


------
https://chatgpt.com/codex/tasks/task_e_686da314d100832a80ded4ee7baee5b2