### PR TITLE
feat: add history navigation

### DIFF
--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -154,4 +154,44 @@ void main() {
     expect(find.text('(2 / 2)'), findsOneWidget);
     expect(prefs.getInt('bookmark_pageIndex'), 1);
   });
+
+  testWidgets('back arrow returns to the previous page', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+      home: WordbookScreen(
+        flashcards: cards,
+        prefsProvider: () async => prefs,
+      ),
+    ));
+    await tester.drag(find.byType(PageView), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(PageView));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.arrow_back));
+    await tester.pumpAndSettle();
+    expect(find.text('(1 / 2)'), findsOneWidget);
+    expect(prefs.getInt('bookmark_pageIndex'), 0);
+  });
+
+  testWidgets('forward arrow goes forward after going back', (tester) async {
+    SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 0});
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(MaterialApp(
+      home: WordbookScreen(
+        flashcards: cards,
+        prefsProvider: () async => prefs,
+      ),
+    ));
+    await tester.drag(find.byType(PageView), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(PageView));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.arrow_back));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.arrow_forward));
+    await tester.pumpAndSettle();
+    expect(find.text('(2 / 2)'), findsOneWidget);
+    expect(prefs.getInt('bookmark_pageIndex'), 1);
+  });
 }


### PR DESCRIPTION
## Why
Allow users to move back and forward through viewed cards.

## What
- add history tracking in `WordbookScreenState`
- add back/forward controls and handlers
- push history on page changes and when restoring bookmark
- tests for new navigation buttons

## How
- updated state with history fields and helper methods
- integrated `_pushHistory`, `_goBack` and `_goForward`
- UI row now shows back/forward icons
- added widget tests for history navigation

- [ ] `dart format --set-exit-if-changed .` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6678764832a9127024b638251eb