### PR TITLE
Fix wordbook history push logic

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -70,6 +70,9 @@ class WordbookScreenState extends State<WordbookScreen> {
   }
 
   void _pushHistory(int index) {
+    if (_historyIndex >= 0 && _history[_historyIndex] == index) {
+      return;
+    }
     if (_historyIndex >= 0 && _historyIndex < _history.length - 1) {
       _history.removeRange(_historyIndex + 1, _history.length);
     }


### PR DESCRIPTION
## Why
Prevent duplicate entries in wordbook history and verify navigation works after search or related term jumps.

## What
- avoid pushing same index to history
- add tests for single-step back/forward after search or related term

## How
- updated `_pushHistory` to check current index
- extended test suite with new cases and helper

- [ ] `dart format --set-exit-if-changed .`
- [ ] `dart test`

------
https://chatgpt.com/codex/tasks/task_e_686e2b431574832a8e665ed60ac5640e