### PR TITLE
fix: avoid navigation when tapping favorite star

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -6,6 +6,8 @@ import 'flashcard_model.dart';
 import 'word_detail_content.dart';
 import 'constants.dart';
 
+const double _edgeTapTopPadding = 72.0;
+
 class WordbookScreen extends StatefulWidget {
   final List<Flashcard> flashcards;
   final Future<SharedPreferences> Function() prefsProvider;
@@ -180,19 +182,19 @@ class WordbookScreenState extends State<WordbookScreen> {
         ),
         // Tappable areas for page navigation on phones
         if (widget.flashcards.length > 1 && !_showControls) ...[
-          const Positioned(
+          Positioned(
             left: 0,
-            top: 0,
+            top: MediaQuery.of(context).padding.top + _edgeTapTopPadding,
             bottom: 0,
             width: 48,
-            child: _EdgeTapArea(isLeft: true),
+            child: const _EdgeTapArea(isLeft: true),
           ),
-          const Positioned(
+          Positioned(
             right: 0,
-            top: 0,
+            top: MediaQuery.of(context).padding.top + _edgeTapTopPadding,
             bottom: 0,
             width: 48,
-            child: _EdgeTapArea(isLeft: false),
+            child: const _EdgeTapArea(isLeft: false),
           ),
         ],
         if (isTabletOrDesktop && widget.flashcards.length > 1)


### PR DESCRIPTION
## Why
Tapping on the favorite star near the screen edge unintentionally triggered page navigation.

## What
- introduce `_edgeTapTopPadding` constant
- move `_EdgeTapArea` below the star button

## How
- adjusted `Positioned` widgets in `WordbookScreen`

------
https://chatgpt.com/codex/tasks/task_e_686e56aa1d4c832a94d71d57857c7a02