### PR TITLE
Fix settings navigation argument

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -237,7 +237,8 @@ class _MainScreenState extends ConsumerState<MainScreen> {
                 ? IconButton(
                     icon: const Icon(Icons.arrow_back),
                     onPressed: () {
-                      _navigateTo(screenToNavigateBack);
+                      _navigateTo(screenToNavigateBack,
+                          args: _currentArguments);
                     },
                   )
                 : null),
@@ -281,7 +282,8 @@ class _MainScreenState extends ConsumerState<MainScreen> {
               icon: const Icon(Icons.settings_outlined),
               tooltip: '設定',
               onPressed: () {
-                _navigateTo(AppScreen.settings);
+                _navigateTo(AppScreen.settings,
+                    args: _currentArguments);
               },
             ),
         ],


### PR DESCRIPTION
## Why
Settings screen lost previous arguments when opening and closing.

## What
- pass current arguments when opening settings
- pass arguments when navigating back

## How
- simple state update

- [ ] dart format run


------
https://chatgpt.com/codex/tasks/task_e_686f70408140832a9568686830420987