### PR TITLE
Add key and update logic

### DIFF
--- a/lib/word_detail_content.dart
+++ b/lib/word_detail_content.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
+import 'package:flutter/foundation.dart';
 
 import 'flashcard_model.dart';
 import 'word_detail_controller.dart';
@@ -60,6 +61,15 @@ class _WordDetailContentState extends ConsumerState<WordDetailContent> {
       goForward: () => _historyController.forward(),
       currentFlashcard: () => _historyController.currentFlashcard,
     );
+  }
+
+  @override
+  void didUpdateWidget(covariant WordDetailContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!listEquals(widget.flashcards, oldWidget.flashcards) ||
+        widget.initialIndex != oldWidget.initialIndex) {
+      _historyController.initialize(widget.flashcards, widget.initialIndex);
+    }
   }
 
   void _onHistoryChanged() {

--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -174,6 +174,7 @@ class WordbookScreenState extends State<WordbookScreen> {
               },
             itemBuilder: (context, index) {
               return WordDetailContent(
+                key: ValueKey(widget.flashcards[index].id),
                 flashcards: [widget.flashcards[index]],
                 initialIndex: 0,
                 showNavigation: false,


### PR DESCRIPTION
## Summary
- add keys to `WordDetailContent` in `PageView` items
- refresh `WordHistoryController` when `WordDetailContent` props change

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7c9042bc832a84feb24f47a72b3b