### PR TITLE
Add bookmark feature

### DIFF
--- a/lib/bookmark_list_screen.dart
+++ b/lib/bookmark_list_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+import 'services/bookmark_service.dart';
+
+class BookmarkListScreen extends StatelessWidget {
+  final BookmarkService service;
+
+  const BookmarkListScreen({super.key, required this.service});
+
+  @override
+  Widget build(BuildContext context) {
+    final bookmarks = service.allBookmarks();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Bookmarks')),
+      body: ListView.builder(
+        itemCount: bookmarks.length,
+        itemBuilder: (context, i) {
+          final b = bookmarks[i];
+          return ListTile(
+            title: Text('Page ${b.pageIndex + 1}'),
+            onTap: () => Navigator.of(context).pop(b.pageIndex),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -5,6 +5,7 @@ const String flashcardStateBoxName = 'flashcard_state_box';
 const String sessionLogBoxName = 'session_log_box_v1';
 const String reviewQueueBoxName = 'review_queue_box_v1';
 const String settingsBoxName = 'settings_box';
+const String bookmarksBoxName = 'bookmarks_box_v1';
 
 // 端末サイズ判定用のブレークポイント (単位: dp)
 const double kTabletBreakpoint = 600.0;

--- a/lib/models/bookmark.dart
+++ b/lib/models/bookmark.dart
@@ -1,0 +1,15 @@
+import 'package:hive/hive.dart';
+
+part 'bookmark.g.dart';
+
+@HiveType(typeId: 9)
+class Bookmark extends HiveObject {
+  @HiveField(0)
+  final int pageIndex;
+
+  @HiveField(1)
+  DateTime updated;
+
+  Bookmark({required this.pageIndex, DateTime? updated})
+      : updated = updated ?? DateTime.now();
+}

--- a/lib/services/bookmark_service.dart
+++ b/lib/services/bookmark_service.dart
@@ -1,0 +1,28 @@
+import 'package:hive/hive.dart';
+
+import '../constants.dart';
+import '../models/bookmark.dart';
+
+class BookmarkService {
+  final Box<Bookmark> _box;
+
+  BookmarkService([Box<Bookmark>? box])
+      : _box = box ?? Hive.box<Bookmark>(bookmarksBoxName);
+
+  Future<void> addBookmark(int pageIndex) async {
+    final entry = Bookmark(pageIndex: pageIndex, updated: DateTime.now());
+    await _box.put(pageIndex, entry);
+  }
+
+  Future<void> removeBookmark(int pageIndex) async {
+    await _box.delete(pageIndex);
+  }
+
+  bool isBookmarked(int pageIndex) => _box.containsKey(pageIndex);
+
+  List<Bookmark> allBookmarks() {
+    final bookmarks = _box.values.toList();
+    bookmarks.sort((a, b) => a.pageIndex.compareTo(b.pageIndex));
+    return bookmarks;
+  }
+}

--- a/lib/services/box_initializer.dart
+++ b/lib/services/box_initializer.dart
@@ -9,6 +9,7 @@ import '../models/review_queue.dart';
 import '../models/saved_theme_mode.dart';
 import '../models/session_log.dart';
 import '../models/word.dart';
+import '../models/bookmark.dart';
 import 'learning_repository.dart';
 import 'word_repository.dart';
 
@@ -48,6 +49,7 @@ Future<void> openAllBoxes(HiveAesCipher cipher) async {
     _openBoxWithMigration<SessionLog>(sessionLogBoxName, cipher),
     _openBoxWithMigration<ReviewQueue>(reviewQueueBoxName, cipher),
     _openBoxWithMigration<SavedThemeMode>(settingsBoxName, cipher),
+    _openBoxWithMigration<Bookmark>(bookmarksBoxName, cipher),
   ];
   await Future.wait(tasks);
 }

--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -11,6 +11,7 @@ import 'package:tango/models/review_queue.dart';
 import 'package:tango/models/saved_theme_mode.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/models/word.dart';
+import 'package:tango/models/bookmark.dart';
 import 'package:tango/services/box_initializer.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/word_repository.dart';
@@ -30,6 +31,7 @@ void main() {
       ReviewQueueAdapter(),
       SavedThemeModeAdapter(),
       FlashcardStateAdapter(),
+      BookmarkAdapter(),
     ];
     for (final adapter in adapters) {
       if (!Hive.isAdapterRegistered(adapter.typeId)) {
@@ -49,6 +51,7 @@ void main() {
       sessionLogBoxName,
       reviewQueueBoxName,
       settingsBoxName,
+      bookmarksBoxName,
     ];
     for (final name in boxes) {
       if (await Hive.boxExists(name)) {
@@ -71,6 +74,7 @@ void main() {
     expect(Hive.isBoxOpen(sessionLogBoxName), isTrue);
     expect(Hive.isBoxOpen(reviewQueueBoxName), isTrue);
     expect(Hive.isBoxOpen(settingsBoxName), isTrue);
+    expect(Hive.isBoxOpen(bookmarksBoxName), isTrue);
   });
 
   test('openAllBoxes recovers when both opens fail', () async {


### PR DESCRIPTION
## Summary
- define `Bookmark` model with Hive support
- register bookmarks box in Hive initialization
- implement `BookmarkService`
- integrate bookmark management in `WordbookScreen`
- show bookmark tick marks on slider and add bookmark list screen
- update tests for new Hive bookmark box and bookmark UI

## Testing
- `dart format lib/models/bookmark.dart lib/bookmark_list_screen.dart lib/services/bookmark_service.dart lib/services/box_initializer.dart lib/constants.dart lib/wordbook_screen.dart test/box_initializer_test.dart test/wordbook_screen_test.dart` *(fails: command not found)*
- `dart run build_runner build --delete-conflicting-outputs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687088b97454832a84192157edf1d917