### PR TITLE
Fix constructor const usage

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -17,7 +17,7 @@ class WordbookScreen extends StatefulWidget {
   final ValueChanged<int>? onIndexChanged;
   final BookmarkService bookmarkService;
 
-  const WordbookScreen({
+  WordbookScreen({
     Key? key,
     required this.flashcards,
     this.prefsProvider = SharedPreferences.getInstance,


### PR DESCRIPTION
## Why
Constructor shouldn't be constant so it can accept non-const parameters.

## What
- removed `const` keyword from `WordbookScreen` constructor

## How
- simple code update
- attempted `dart format` but Dart SDK isn't available


------
https://chatgpt.com/codex/tasks/task_e_68709db85958832a8b21441329bca243