### PR TITLE
Add hive_test to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dev_dependencies:
     sdk: flutter
   hive_generator: ^2.0.1 # Hiveオブジェクトを生成するために必要
   build_runner: ^2.4.0   # コードジェネレータを実行するために必要
+  hive_test: ^1.0.0
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your


### PR DESCRIPTION
## Why
- prepare for Hive related testing

## What
- add `hive_test` package to `dev_dependencies`

## How
- update `pubspec.yaml`

No formatting or dependency update commands could be run because `dart` and `flutter` are not installed in the environment.


------
https://chatgpt.com/codex/tasks/task_e_68779bddc3d4832aa6648a7e57ea171e