### PR TITLE
fix: specify adapter list type

### DIFF
--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -22,7 +22,7 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    final adapters = [
+    final adapters = <TypeAdapter<dynamic>>[
       HistoryEntryAdapter(),
       WordAdapter(),
       LearningStatAdapter(),


### PR DESCRIPTION
## Why
- `adapter.typeId` access in tests fails because the adapter list had type `List<dynamic>`

## What
- declare `adapters` in `box_initializer_test.dart` with `List<TypeAdapter<dynamic>>`

## How
- small Dart edit; ran `dart format` but command was unavailable in the environment


------
https://chatgpt.com/codex/tasks/task_e_6877a6bee388832a8dd5625fc9d696de