### PR TITLE
test: open favorites box in word list query test

### DIFF
--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -1,8 +1,26 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tango/constants.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/word_list_query.dart';
 
 void main() {
+  late Directory dir;
+  late Box<Map> favBox;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    favBox = await Hive.openBox<Map>(favoritesBoxName);
+  });
+
+  tearDown(() async {
+    await favBox.close();
+    await Hive.deleteBoxFromDisk(favoritesBoxName);
+    await dir.delete(recursive: true);
+  });
   final card1 = Flashcard(
     id: '1',
     term: 'a',


### PR DESCRIPTION
## Why
WordListQuery reads from the favorites Hive box. The existing unit test did not
initialize Hive, causing failures once favorites access was added.

## What
- initialize a temporary Hive directory in `setUp`
- open `favoritesBoxName` as `Box<Map>`
- close and delete the box in `tearDown`

## How
- updated imports for Hive and constants
- created setup/teardown logic in the test file


------
https://chatgpt.com/codex/tasks/task_e_6877a8ad60f4832abbc551ad87e14419