### PR TITLE
Fix adapter registration in theme mode tests

### DIFF
--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -16,7 +16,9 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(SavedThemeModeAdapter());
+    if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
+      Hive.registerAdapter(SavedThemeModeAdapter());
+    }
     box = await Hive.openBox<SavedThemeMode>(settingsBoxName);
     notifier = ThemeModeNotifier(box);
     await notifier.load();


### PR DESCRIPTION
## Why
Avoid `HiveError` when the adapter is already registered.

## What
- check for existing adapter before calling `Hive.registerAdapter`

## How
- updated `test/theme_mode_provider_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_687828fb9294832ab0607b8904558be2