### PR TITLE
test: ensure Hive cleanup

### DIFF
--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -58,6 +58,7 @@ void main() {
         await Hive.deleteBoxFromDisk(name);
       }
     }
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -16,8 +16,12 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(WordAdapter());
-    Hive.registerAdapter(LearningStatAdapter());
+    if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
+      Hive.registerAdapter(WordAdapter());
+    }
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
     wordRepo = await WordRepository.open();
     learningRepo = await LearningRepository.open();
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);
@@ -26,6 +30,7 @@ void main() {
   tearDown(() async {
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -16,8 +16,12 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(HistoryEntryAdapter());
-    Hive.registerAdapter(QuizStatAdapter());
+    if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
+      Hive.registerAdapter(HistoryEntryAdapter());
+    }
+    if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
+      Hive.registerAdapter(QuizStatAdapter());
+    }
     historyBox = await Hive.openBox<HistoryEntry>(historyBoxName);
     quizBox = await Hive.openBox<QuizStat>(quizStatsBoxName);
     service = HistoryChartService(historyBox, quizBox);
@@ -28,6 +32,7 @@ void main() {
     await quizBox.close();
     await Hive.deleteBoxFromDisk(historyBoxName);
     await Hive.deleteBoxFromDisk(quizStatsBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -10,12 +10,15 @@ import 'package:tango/constants.dart';
 void main() {
   setUp(() async {
     Hive.init('./testdb_empty');
-    Hive.registerAdapter(SessionLogAdapter());
+    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+      Hive.registerAdapter(SessionLogAdapter());
+    }
     await Hive.openBox<SessionLog>(sessionLogBoxName);
   });
 
   tearDown(() async {
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
+    await Hive.close();
     final dir = Directory('./testdb_empty');
     if (dir.existsSync()) dir.deleteSync(recursive: true);
   });

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -13,7 +13,9 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(HistoryEntryAdapter());
+    if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
+      Hive.registerAdapter(HistoryEntryAdapter());
+    }
     box = await Hive.openBox<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
   });
@@ -21,6 +23,7 @@ void main() {
   tearDown(() async {
     await box.close();
     await Hive.deleteBoxFromDisk(historyBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -19,6 +19,7 @@ void main() {
 
   tearDown(() async {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -50,9 +50,15 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(ReviewQueueAdapter());
-    Hive.registerAdapter(LearningStatAdapter());
-    Hive.registerAdapter(WordAdapter());
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
+    if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
+      Hive.registerAdapter(WordAdapter());
+    }
     queueBox = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     favBox = await Hive.openBox<Map>(favoritesBoxName);
     statBox = await Hive.openBox<LearningStat>(LearningRepository.boxName);
@@ -70,6 +76,7 @@ void main() {
     await Hive.deleteBoxFromDisk(favoritesBoxName);
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -13,7 +13,9 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(ReviewQueueAdapter());
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
     box = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     service = ReviewQueueService(box);
   });
@@ -21,6 +23,7 @@ void main() {
   tearDown(() async {
     await box.close();
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -20,7 +20,9 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(SessionLogAdapter());
+    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+      Hive.registerAdapter(SessionLogAdapter());
+    }
     box = await Hive.openBox<SessionLog>(sessionLogBoxName);
     aggregator = SessionAggregator(box);
   });
@@ -28,6 +30,7 @@ void main() {
   tearDown(() async {
     await box.close();
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -32,9 +32,15 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(SessionLogAdapter());
-    Hive.registerAdapter(LearningStatAdapter());
-    Hive.registerAdapter(ReviewQueueAdapter());
+    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+      Hive.registerAdapter(SessionLogAdapter());
+    }
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
     logBox = await Hive.openBox<SessionLog>(sessionLogBoxName);
     statBox = await Hive.openBox<LearningStat>(LearningRepository.boxName);
     boxQueue = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
@@ -48,6 +54,7 @@ void main() {
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -15,9 +15,15 @@ import 'package:tango/study_start_sheet.dart';
 void main() {
   setUpAll(() async {
     Hive.init('./testdb');
-    Hive.registerAdapter(SessionLogAdapter());
-    Hive.registerAdapter(LearningStatAdapter());
-    Hive.registerAdapter(ReviewQueueAdapter());
+    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+      Hive.registerAdapter(SessionLogAdapter());
+    }
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter(ReviewQueueAdapter());
+    }
     await Hive.openBox<SessionLog>(sessionLogBoxName);
     await Hive.openBox<LearningStat>(LearningRepository.boxName);
     await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
@@ -27,6 +33,7 @@ void main() {
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
+    await Hive.close();
   });
 
   Flashcard _card(String id) => Flashcard(

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -27,6 +27,7 @@ void main() {
   tearDown(() async {
     await box.close();
     await Hive.deleteBoxFromDisk(settingsBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -29,7 +29,9 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(HistoryEntryAdapter());
+    if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
+      Hive.registerAdapter(HistoryEntryAdapter());
+    }
     box = await Hive.openBox<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
     controller = WordHistoryController(service);
@@ -39,6 +41,7 @@ void main() {
     controller.dispose();
     await box.close();
     await Hive.deleteBoxFromDisk(historyBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -19,6 +19,7 @@ void main() {
   tearDown(() async {
     await favBox.close();
     await Hive.deleteBoxFromDisk(favoritesBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
   final card1 = Flashcard(

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -19,6 +19,7 @@ void main() {
 
   tearDown(() async {
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -282,7 +282,9 @@ void main() {
   testWidgets('bookmark add/remove stored in Hive', (tester) async {
     final dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(BookmarkAdapter());
+    if (!Hive.isAdapterRegistered(BookmarkAdapter().typeId)) {
+      Hive.registerAdapter(BookmarkAdapter());
+    }
     final box = await Hive.openBox<Bookmark>(bookmarksBoxName);
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -309,6 +311,7 @@ void main() {
 
     await box.close();
     await Hive.deleteBoxFromDisk(bookmarksBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 
@@ -316,7 +319,9 @@ void main() {
       (tester) async {
     final dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    Hive.registerAdapter(BookmarkAdapter());
+    if (!Hive.isAdapterRegistered(BookmarkAdapter().typeId)) {
+      Hive.registerAdapter(BookmarkAdapter());
+    }
     final box = await Hive.openBox<Bookmark>(bookmarksBoxName);
     final service = BookmarkService(box);
     await service.addBookmark(1);
@@ -345,6 +350,7 @@ void main() {
 
     await box.close();
     await Hive.deleteBoxFromDisk(bookmarksBoxName);
+    await Hive.close();
     await dir.delete(recursive: true);
   });
 }


### PR DESCRIPTION
## Why
Hive adapters were re-registered and boxes remained open between tests.

## What
- check adapter registration in each setUp
- close Hive in tearDown/tearDownAll

## How
- modified various test files

------
https://chatgpt.com/codex/tasks/task_e_68782b0a4c68832aac979fe5696588b1