### PR TITLE
Consolidate ProviderScope in test

### DIFF
--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -49,7 +49,6 @@ void main() {
       );
 
   testWidgets('flow one word', (tester) async {
-    final words = [_card('1')];
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -59,12 +58,6 @@ void main() {
             return StudySessionController(logBox, ReviewQueueService(queueBox));
           })
         ],
-        child: const MaterialApp(home: Scaffold()),
-      ),
-    );
-
-    await tester.pumpWidget(
-      ProviderScope(
         child: MaterialApp(
           home: Builder(
             builder: (context) {


### PR DESCRIPTION
## Why
Improve test readability by building ProviderScope and the test UI in a single `pumpWidget` call.

## What
- combine ProviderScope overrides with MaterialApp in `study_session_flow_test`

## How
Updated the test file accordingly.

------
https://chatgpt.com/codex/tasks/task_e_68783083c14c832a92b20aa81273164c