### PR TITLE
Setup bookmark service for WordbookScreen tests

### DIFF
--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -1,7 +1,13 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:hive/hive.dart';
 import 'package:tango/flashcard_model.dart';
+import 'package:tango/models/bookmark.dart';
+import 'package:tango/services/bookmark_service.dart';
+import 'package:tango/constants.dart';
 import 'package:tango/wordbook_screen.dart';
 
 Flashcard _card(int i) => Flashcard(
@@ -21,6 +27,24 @@ Flashcard _card(int i) => Flashcard(
     );
 
 void main() {
+  late Directory tempDir;
+  late Box<Bookmark> box;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    if (!Hive.isAdapterRegistered(BookmarkAdapter().typeId)) {
+      Hive.registerAdapter(BookmarkAdapter());
+    }
+    box = await Hive.openBox<Bookmark>(bookmarksBoxName);
+  });
+
+  tearDown(() async {
+    await box.close();
+    await Hive.deleteBoxFromDisk(bookmarksBoxName);
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
   testWidgets('shows current page indicator in AppBar', (tester) async {
     final cards = List.generate(861, (i) => _card(i + 1));
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 77});
@@ -29,6 +53,7 @@ void main() {
         home: WordbookScreen(
       flashcards: cards,
       prefsProvider: () async => prefs,
+      bookmarkService: BookmarkService(box),
     )));
     await tester.pumpAndSettle();
     expect(find.text('(78 / 861)'), findsOneWidget);


### PR DESCRIPTION
## Why
WordbookScreen relies on Hive to store bookmarks. The tests did not open a
bookmarks box which caused failures when BookmarkService was constructed
without an open box.

## What
- initialize Hive and open the bookmark box in each test suite's `setUp`
- pass `BookmarkService(box)` to WordbookScreen
- clean up the box in `tearDown`

## How
Only test code was updated. Formatting was attempted but `dart` is missing in
the environment.


------
https://chatgpt.com/codex/tasks/task_e_68783332c200832aa32440e95a3074d5