### PR TITLE
Fix word history controller test

### DIFF
--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -42,6 +42,7 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(historyBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 
@@ -49,6 +50,7 @@ void main() {
     fakeAsync((async) {
       controller.initialize([_card('1')], 0);
       async.elapse(const Duration(seconds: 5));
+      async.flushMicrotasks();
     });
     expect(box.get('1'), isNotNull);
   });
@@ -58,6 +60,7 @@ void main() {
       controller.initialize([_card('1'), _card('2')], 0);
       controller.setPage(1);
       async.elapse(const Duration(seconds: 5));
+      async.flushMicrotasks();
     });
     expect(box.get('1'), isNull);
     expect(box.get('2'), isNotNull);


### PR DESCRIPTION
## Why
The word history controller test didn't flush pending microtasks after advancing fake time and didn't fully reset Hive state between runs.

## What
- flush microtasks after `elapse` to ensure timer callbacks run
- call `Hive.reset()` in `tearDown`

## How
- updated `test/word_history_controller_test.dart`

Checklist:
- [ ] Code formatted *(failed: `dart` was unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68784d326dfc832aa80c7fc6b268b1bc