### PR TITLE
fix: missing material import

### DIFF
--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+
 import 'package:tango/history_entry_model.dart';
 import 'package:tango/models/quiz_stat.dart';
 import 'package:tango/services/history_chart_service.dart';


### PR DESCRIPTION
## Why
`DateTimeRange` in the history chart test comes from `material.dart`.

## What
- add `flutter/material.dart` import

## How
- run `dart format --set-exit-if-changed .` *(failed: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687851562874832a9129cb2a4a888630