### PR TITLE
Add Hive.reset in test teardowns

### DIFF
--- a/test/bookmark_box_test_utils.dart
+++ b/test/bookmark_box_test_utils.dart
@@ -19,5 +19,6 @@ Future<void> cleanBookmarkBox(BookmarkContext ctx) async {
   await ctx.box.close();
   await Hive.deleteBoxFromDisk(bookmarksBoxName);
   await Hive.close();
+  Hive.reset();
   await ctx.dir.delete(recursive: true);
 }

--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -59,6 +59,7 @@ void main() {
       }
     }
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -31,6 +31,7 @@ void main() {
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -36,6 +36,7 @@ void main() {
     await Hive.deleteBoxFromDisk(historyBoxName);
     await Hive.deleteBoxFromDisk(quizStatsBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -19,6 +19,7 @@ void main() {
   tearDown(() async {
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
     await Hive.close();
+    Hive.reset();
     final dir = Directory('./testdb_empty');
     if (dir.existsSync()) dir.deleteSync(recursive: true);
   });

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -24,6 +24,7 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(historyBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -20,6 +20,7 @@ void main() {
   tearDown(() async {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -91,6 +91,7 @@ void main() {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -24,6 +24,7 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -31,6 +31,7 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -55,6 +55,7 @@ void main() {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -34,6 +34,7 @@ void main() {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
     await Hive.close();
+    Hive.reset();
   });
 
   Flashcard _card(String id) => Flashcard(

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -28,6 +28,7 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(settingsBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -20,6 +20,7 @@ void main() {
     await favBox.close();
     await Hive.deleteBoxFromDisk(favoritesBoxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
   final card1 = Flashcard(

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -20,6 +20,7 @@ void main() {
   tearDown(() async {
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
     await Hive.close();
+    Hive.reset();
     await dir.delete(recursive: true);
   });
 


### PR DESCRIPTION
## Why
Ensure Hive is properly cleaned up between tests.

## What
- call `Hive.reset()` after closing Hive in all Hive-based tests

## How
- update each test `tearDown`/`tearDownAll` block


------
https://chatgpt.com/codex/tasks/task_e_68786a80df0c832ab8b8a8948b0c8df4