### PR TITLE
Remove Hive reset from tests

### DIFF
--- a/test/bookmark_box_test_utils.dart
+++ b/test/bookmark_box_test_utils.dart
@@ -19,6 +19,5 @@ Future<void> cleanBookmarkBox(BookmarkContext ctx) async {
   await ctx.box.close();
   await Hive.deleteBoxFromDisk(bookmarksBoxName);
   await Hive.close();
-  Hive.reset();
   await ctx.dir.delete(recursive: true);
 }

--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -55,11 +55,10 @@ void main() {
     ];
     for (final name in boxes) {
       if (await Hive.boxExists(name)) {
-        await Hive.deleteBoxFromDisk(name);
+    await Hive.deleteBoxFromDisk(name);
       }
     }
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -31,7 +31,6 @@ void main() {
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -36,7 +36,6 @@ void main() {
     await Hive.deleteBoxFromDisk(historyBoxName);
     await Hive.deleteBoxFromDisk(quizStatsBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -19,7 +19,6 @@ void main() {
   tearDown(() async {
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
     await Hive.close();
-    Hive.reset();
     final dir = Directory('./testdb_empty');
     if (dir.existsSync()) dir.deleteSync(recursive: true);
   });

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -24,7 +24,6 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(historyBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -20,7 +20,6 @@ void main() {
   tearDown(() async {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -91,7 +91,6 @@ void main() {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -24,7 +24,6 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -31,7 +31,6 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(sessionLogBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -55,7 +55,6 @@ void main() {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -34,7 +34,6 @@ void main() {
     await Hive.deleteBoxFromDisk(LearningRepository.boxName);
     await Hive.deleteBoxFromDisk(reviewQueueBoxName);
     await Hive.close();
-    Hive.reset();
   });
 
   Flashcard _card(String id) => Flashcard(

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -28,7 +28,6 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(settingsBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -42,7 +42,6 @@ void main() {
     await box.close();
     await Hive.deleteBoxFromDisk(historyBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -20,7 +20,6 @@ void main() {
     await favBox.close();
     await Hive.deleteBoxFromDisk(favoritesBoxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
   final card1 = Flashcard(

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -20,7 +20,6 @@ void main() {
   tearDown(() async {
     await Hive.deleteBoxFromDisk(WordRepository.boxName);
     await Hive.close();
-    Hive.reset();
     await dir.delete(recursive: true);
   });
 


### PR DESCRIPTION
## Why
`Hive.reset()` is deprecated and unnecessary in cleanup. Tests should simply close Hive and delete boxes.

## What
- remove `Hive.reset();` lines from test teardowns

## How
- edited 16 test files
- `dart format` failed due to missing Dart SDK


------
https://chatgpt.com/codex/tasks/task_e_687875a29e44832abd38a7d80f7fac04