### PR TITLE
test: provide fake flashcard repository

### DIFF
--- a/test/fakes/fake_flashcard_repository.dart
+++ b/test/fakes/fake_flashcard_repository.dart
@@ -1,0 +1,21 @@
+import 'package:tango/flashcard_model.dart';
+import 'package:tango/flashcard_repository.dart';
+import 'package:tango/word_list_query.dart';
+import 'package:tango/services/flashcard_loader.dart';
+
+class FakeFlashcardRepository implements FlashcardRepository {
+  final List<Flashcard> _cards;
+
+  FakeFlashcardRepository(this._cards);
+
+  @override
+  void setLoader(FlashcardLoader loader) {}
+
+  @override
+  Future<List<Flashcard>> loadAll() async => _cards;
+
+  @override
+  Future<List<Flashcard>> fetch(WordListQuery query) async {
+    return query.apply(_cards);
+  }
+}

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -9,8 +9,10 @@ import 'package:tango/models/session_log.dart';
 import 'package:tango/models/review_queue.dart';
 import 'package:tango/services/review_queue_service.dart';
 import 'package:tango/services/learning_repository.dart';
+import 'package:tango/flashcard_repository_provider.dart';
 import 'package:tango/study_session_controller.dart';
 import 'package:tango/study_start_sheet.dart';
+import 'fakes/fake_flashcard_repository.dart';
 
 void main() {
   setUpAll(() async {
@@ -56,7 +58,10 @@ void main() {
             final logBox = Hive.box<SessionLog>(sessionLogBoxName);
             final queueBox = Hive.box<ReviewQueue>(reviewQueueBoxName);
             return StudySessionController(logBox, ReviewQueueService(queueBox));
-          })
+          }),
+          flashcardRepositoryProvider.overrideWithValue(
+            FakeFlashcardRepository([_card('0')]),
+          )
         ],
         child: MaterialApp(
           home: Builder(


### PR DESCRIPTION
## Summary
- add FakeFlashcardRepository for widget tests
- override flashcard repository in study_session_flow_test

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b4bbaf48832aaf153e97f51fc910