### PR TITLE
Improve test setup with shared Hive harness

### DIFF
--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -6,32 +6,23 @@ import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/word_repository.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/flashcard_loader.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late WordRepository wordRepo;
   late LearningRepository learningRepo;
   late HiveFlashcardLoader loader;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
-      Hive.registerAdapter(WordAdapter());
-    }
-    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
-      Hive.registerAdapter(LearningStatAdapter());
-    }
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
     wordRepo = await WordRepository.open();
     learningRepo = await LearningRepository.open();
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);
   });
 
-  tearDown(() async {
-    await Hive.deleteBoxFromDisk(WordRepository.boxName);
-    await Hive.deleteBoxFromDisk(LearningRepository.boxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('loads flashcards with stats merged', () async {

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -9,34 +9,23 @@ import 'package:tango/models/quiz_stat.dart';
 import 'package:tango/services/history_chart_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/learning_history_detail_screen.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late Box<HistoryEntry> historyBox;
   late Box<QuizStat> quizBox;
   late HistoryChartService service;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
-      Hive.registerAdapter(HistoryEntryAdapter());
-    }
-    if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
-      Hive.registerAdapter(QuizStatAdapter());
-    }
-    historyBox = await Hive.openBox<HistoryEntry>(historyBoxName);
-    quizBox = await Hive.openBox<QuizStat>(quizStatsBoxName);
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    historyBox = Hive.box<HistoryEntry>(historyBoxName);
+    quizBox = Hive.box<QuizStat>(quizStatsBoxName);
     service = HistoryChartService(historyBox, quizBox);
   });
 
-  tearDown(() async {
-    await historyBox.close();
-    await quizBox.close();
-    await Hive.deleteBoxFromDisk(historyBoxName);
-    await Hive.deleteBoxFromDisk(quizStatsBoxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('calculates chart data', () async {

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -6,21 +6,17 @@ import 'package:hive/hive.dart';
 import 'package:tango/history_screen.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/constants.dart';
+import 'test_harness.dart';
 
 void main() {
-  setUp(() async {
-    Hive.init('./testdb_empty');
-    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
-      Hive.registerAdapter(SessionLogAdapter());
-    }
-    await Hive.openBox<SessionLog>(sessionLogBoxName);
+  late Directory hiveTempDir;
+
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
   });
 
-  tearDown(() async {
-    await Hive.deleteBoxFromDisk(sessionLogBoxName);
-    await Hive.close();
-    final dir = Directory('./testdb_empty');
-    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   testWidgets('shows empty message when no data', (tester) async {

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -1,30 +1,25 @@
 import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/history_service.dart';
 import 'package:tango/constants.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late Box<HistoryEntry> box;
   late HistoryService service;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
-      Hive.registerAdapter(HistoryEntryAdapter());
-    }
-    box = await Hive.openBox<HistoryEntry>(historyBoxName);
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    box = Hive.box<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
   });
 
-  tearDown(() async {
-    await box.close();
-    await Hive.deleteBoxFromDisk(historyBoxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('adds unique entries', () async {

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -1,26 +1,22 @@
 import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/learning_repository.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late LearningRepository repo;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
-      Hive.registerAdapter(LearningStatAdapter());
-    }
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
     repo = await LearningRepository.open();
   });
 
-  tearDown(() async {
-    await Hive.deleteBoxFromDisk(LearningRepository.boxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('stores and retrieves stats', () async {

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -1,30 +1,25 @@
 import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/models/review_queue.dart';
 import 'package:tango/services/review_queue_service.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late Box<ReviewQueue> box;
   late ReviewQueueService service;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
-      Hive.registerAdapter(ReviewQueueAdapter());
-    }
-    box = await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    box = Hive.box<ReviewQueue>(reviewQueueBoxName);
     service = ReviewQueueService(box);
   });
 
-  tearDown(() async {
-    await box.close();
-    await Hive.deleteBoxFromDisk(reviewQueueBoxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('push limits queue to 200 and drops oldest', () async {

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -7,35 +7,26 @@ import 'package:tango/flashcard_model.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/models/review_queue.dart';
+import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/review_queue_service.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/flashcard_repository_provider.dart';
 import 'package:tango/study_session_controller.dart';
 import 'package:tango/study_start_sheet.dart';
 import 'fakes/fake_flashcard_repository.dart';
+import 'test_harness.dart';
 
 void main() {
+  late Directory hiveTempDir;
+
   setUpAll(() async {
-    Hive.init('./testdb');
-    if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
-      Hive.registerAdapter(SessionLogAdapter());
-    }
-    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
-      Hive.registerAdapter(LearningStatAdapter());
-    }
-    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
-      Hive.registerAdapter(ReviewQueueAdapter());
-    }
-    await Hive.openBox<SessionLog>(sessionLogBoxName);
-    await Hive.openBox<LearningStat>(LearningRepository.boxName);
+    hiveTempDir = await initHiveForTests();
     await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+    await Hive.openBox<HistoryEntry>(historyBoxName);
   });
 
   tearDownAll(() async {
-    await Hive.deleteBoxFromDisk(sessionLogBoxName);
-    await Hive.deleteBoxFromDisk(LearningRepository.boxName);
-    await Hive.deleteBoxFromDisk(reviewQueueBoxName);
-    await Hive.close();
+    await closeHiveForTests(hiveTempDir);
   });
 
   Flashcard _card(String id) => Flashcard(

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:hive/hive.dart';
+
+import '../lib/constants.dart';
+import '../lib/history_entry_model.dart';
+import '../lib/models/bookmark.dart';
+import '../lib/models/flashcard_state.dart';
+import '../lib/models/learning_stat.dart';
+import '../lib/models/quiz_stat.dart';
+import '../lib/models/review_queue.dart';
+import '../lib/models/saved_theme_mode.dart';
+import '../lib/models/session_log.dart';
+import '../lib/models/word.dart';
+import '../lib/services/learning_repository.dart';
+import '../lib/services/word_repository.dart';
+
+/// Initialize Hive for tests and open all required boxes.
+Future<Directory> initHiveForTests() async {
+  final dir = await Directory.systemTemp.createTemp();
+  Hive.init(dir.path);
+  final adapters = <TypeAdapter<dynamic>>[
+    SavedThemeModeAdapter(),
+    ReviewQueueAdapter(),
+    HistoryEntryAdapter(),
+    SessionLogAdapter(),
+    LearningStatAdapter(),
+    WordAdapter(),
+    QuizStatAdapter(),
+    FlashcardStateAdapter(),
+    BookmarkAdapter(),
+  ];
+  for (final adapter in adapters) {
+    if (!Hive.isAdapterRegistered(adapter.typeId)) {
+      Hive.registerAdapter(adapter);
+    }
+  }
+  await Hive.openBox<SavedThemeMode>(settingsBoxName);
+  await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+  await Hive.openBox<HistoryEntry>(historyBoxName);
+  await Hive.openBox<SessionLog>(sessionLogBoxName);
+  await Hive.openBox<LearningStat>(LearningRepository.boxName);
+  await Hive.openBox<Map>(favoritesBoxName);
+  await Hive.openBox<QuizStat>(quizStatsBoxName);
+  await Hive.openBox<Word>(WordRepository.boxName);
+  await Hive.openBox<Bookmark>(bookmarksBoxName);
+  await Hive.openBox<FlashcardState>(flashcardStateBoxName);
+  return dir;
+}
+
+/// Close and delete all Hive boxes used for tests.
+Future<void> closeHiveForTests(Directory dir) async {
+  for (final box in Hive.boxes.values) {
+    await box.close();
+    await box.deleteFromDisk();
+  }
+  await Hive.close();
+  await dir.delete(recursive: true);
+}

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -7,28 +7,22 @@ import 'package:hive/hive.dart';
 import 'package:tango/theme_mode_provider.dart';
 import 'package:tango/models/saved_theme_mode.dart';
 import 'package:tango/constants.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late Box<SavedThemeMode> box;
   late ThemeModeNotifier notifier;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
-      Hive.registerAdapter(SavedThemeModeAdapter());
-    }
-    box = await Hive.openBox<SavedThemeMode>(settingsBoxName);
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    box = Hive.box<SavedThemeMode>(settingsBoxName);
     notifier = ThemeModeNotifier(box);
     await notifier.load();
   });
 
-  tearDown(() async {
-    await box.close();
-    await Hive.deleteBoxFromDisk(settingsBoxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('initial value system', () {

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/history_service.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/constants.dart';
+import 'test_harness.dart';
 
 Flashcard _card(String id) => Flashcard(
       id: id,
@@ -21,28 +22,21 @@ Flashcard _card(String id) => Flashcard(
     );
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late Box<HistoryEntry> box;
   late HistoryService service;
   late WordHistoryController controller;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
-      Hive.registerAdapter(HistoryEntryAdapter());
-    }
-    box = await Hive.openBox<HistoryEntry>(historyBoxName);
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    box = Hive.box<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
     controller = WordHistoryController(service);
   });
 
-  tearDown(() async {
+  tearDownAll(() async {
     controller.dispose();
-    await box.close();
-    await Hive.deleteBoxFromDisk(historyBoxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('records view after delay', () {

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -5,22 +5,19 @@ import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/word_list_query.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late Box<Map> favBox;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    favBox = await Hive.openBox<Map>(favoritesBoxName);
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    favBox = Hive.box<Map>(favoritesBoxName);
   });
 
-  tearDown(() async {
-    await favBox.close();
-    await Hive.deleteBoxFromDisk(favoritesBoxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
   final card1 = Flashcard(
     id: '1',

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -3,24 +3,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/word.dart';
 import 'package:tango/services/word_repository.dart';
+import 'test_harness.dart';
 
 void main() {
-  late Directory dir;
+  late Directory hiveTempDir;
   late WordRepository repo;
 
-  setUp(() async {
-    dir = await Directory.systemTemp.createTemp();
-    Hive.init(dir.path);
-    if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
-      Hive.registerAdapter(WordAdapter());
-    }
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
     repo = await WordRepository.open();
   });
 
-  tearDown(() async {
-    await Hive.deleteBoxFromDisk(WordRepository.boxName);
-    await Hive.close();
-    await dir.delete(recursive: true);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
 
   test('adds and fetches word', () async {

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -6,10 +6,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/models/bookmark.dart';
+import 'package:tango/models/review_queue.dart';
+import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/bookmark_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/wordbook_screen.dart';
-import 'bookmark_box_test_utils.dart';
+import 'test_harness.dart';
 
 Flashcard _card(int i) => Flashcard(
       id: '$i',
@@ -28,16 +30,18 @@ Flashcard _card(int i) => Flashcard(
     );
 
 void main() {
-  late BookmarkContext ctx;
+  late Directory hiveTempDir;
   late Box<Bookmark> box;
 
-  setUp(() async {
-    ctx = await initBookmarkBox();
-    box = ctx.box;
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+    await Hive.openBox<HistoryEntry>(historyBoxName);
+    box = Hive.box<Bookmark>(bookmarksBoxName);
   });
 
-  tearDown(() async {
-    await cleanBookmarkBox(ctx);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
   testWidgets('shows current page indicator in AppBar', (tester) async {
     final cards = List.generate(861, (i) => _card(i + 1));

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -9,7 +9,7 @@ import 'package:tango/models/bookmark.dart';
 import 'package:tango/services/bookmark_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/wordbook_screen.dart';
-import 'bookmark_box_test_utils.dart';
+import 'test_harness.dart';
 
 Flashcard _card(String id, String term) => Flashcard(
       id: id,
@@ -46,16 +46,16 @@ Flashcard _cardWithRelated(String id, String term, List<String> related) =>
     );
 
 void main() {
-  late BookmarkContext ctx;
+  late Directory hiveTempDir;
   late Box<Bookmark> box;
 
-  setUp(() async {
-    ctx = await initBookmarkBox();
-    box = ctx.box;
+  setUpAll(() async {
+    hiveTempDir = await initHiveForTests();
+    box = Hive.box<Bookmark>(bookmarksBoxName);
   });
 
-  tearDown(() async {
-    await cleanBookmarkBox(ctx);
+  tearDownAll(() async {
+    await closeHiveForTests(hiveTempDir);
   });
   final cards = [_card('1', 'a'), _card('2', 'b')];
 


### PR DESCRIPTION
## Why
Simplify test setup and speed up execution by reusing a common Hive initialization routine.

## What
- add `test/test_harness.dart` for initializing and tearing down Hive
- replace per-test Hive setup/teardown with `initHiveForTests`/`closeHiveForTests`
- open additional Hive boxes where required

## How
- created shared helpers that register all adapters and open needed boxes
- updated all Hive‐using tests to use the helpers with `setUpAll`/`tearDownAll`


------
https://chatgpt.com/codex/tasks/task_e_6878eb39b24c832aa17f090c06c168b6