### PR TITLE
Fix LearningRepository adapter registration

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -12,6 +12,9 @@ class LearningRepository {
 
   /// Open the Hive box used for stats.
   static Future<LearningRepository> open() async {
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
     final box = await Hive.openBox<LearningStat>(boxName);
     return LearningRepository._(box);
   }


### PR DESCRIPTION
## Summary
- ensure `LearningRepository.open()` registers `LearningStatAdapter`

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792f71326c832a8963149fef13eec3