### PR TITLE
Fix Hive test harness for favorites

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -5,6 +5,9 @@ import 'package:hive/hive.dart';
 import '../lib/models/learning_stat.dart';
 import '../lib/models/saved_theme_mode.dart';
 import '../lib/models/word.dart';
+import '../lib/constants.dart';
+import '../lib/services/learning_repository.dart';
+import '../lib/services/word_repository.dart';
 
 final List<Box<dynamic>> _openedBoxes = [];
 
@@ -23,10 +26,15 @@ Future<Directory> initHiveForTests() async {
 
   // The boxes we need in every test
   const boxNames = [
-    'settings_box',
-    'review_queue_box_v1',
-    'history_box_v2',
-    'learning_stats_box_v1',
+    settingsBoxName,
+    reviewQueueBoxName,
+    historyBoxName,
+    LearningRepository.boxName,
+    sessionLogBoxName,
+    favoritesBoxName,
+    WordRepository.boxName,
+    bookmarksBoxName,
+    quizStatsBoxName,
   ];
 
   for (final name in boxNames) {


### PR DESCRIPTION
## Why
Flutter tests failed with `HiveError: Box not found` because the favorites box and other boxes were not opened in the test harness.

## What
- include constants and repository names in test harness
- open all boxes required by unit tests (favorites, bookmarks, stats, etc.)

## How
- updated `test/test_harness.dart`
- `dart format` failed because Dart SDK isn't available in the environment

Closes #??? (if any)

------
https://chatgpt.com/codex/tasks/task_e_687a351511f8832a94e70eb5ed4975d4