### PR TITLE
Fix Hive box reopening in tests

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -12,7 +12,12 @@ class LearningRepository {
 
   /// Open the Hive box used for stats.
   static Future<LearningRepository> open() async {
-    final box = await Hive.openBox<LearningStat>(boxName);
+    final Box<LearningStat> box;
+    if (Hive.isBoxOpen(boxName)) {
+      box = Hive.box(boxName).cast<LearningStat>();
+    } else {
+      box = await Hive.openBox<LearningStat>(boxName);
+    }
     return LearningRepository._(box);
   }
 


### PR DESCRIPTION
## Why
LearningRepository.open() attempted to open a Hive box that had already been opened in `initHiveForTests` without type information, causing `HiveError` during tests.

## What
- Detect when the stats box is already open and cast it to the proper type.

## How
- Added `isBoxOpen` check and `.cast<LearningStat>()` before opening a new box.

Checklist:
- [ ] `dart format` *(failed: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a384cf5c4832aa980318077170ff0