### PR TITLE
Fix Hive box retrieval

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -14,7 +14,7 @@ class LearningRepository {
   static Future<LearningRepository> open() async {
     final Box<LearningStat> box;
     if (Hive.isBoxOpen(boxName)) {
-      box = Hive.box(boxName).cast<LearningStat>();
+      box = Hive.box<LearningStat>(boxName);
     } else {
       box = await Hive.openBox<LearningStat>(boxName);
     }


### PR DESCRIPTION
## Summary
- fix LearningRepository to use typed `Hive.box<LearningStat>()`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a3cbc27b8832a8898dd555d310ddb