### PR TITLE
fix: return opened LearningStat box

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -11,14 +11,16 @@ class LearningRepository {
   LearningRepository._(this._box);
 
   /// Open the Hive box used for stats.
-  static Future<LearningRepository> open() async {
-    final Box<LearningStat> box;
+  static Future<Box<LearningStat>> open() async {
     if (Hive.isBoxOpen(boxName)) {
-      box = Hive.box<LearningStat>(boxName);
-    } else {
-      box = await Hive.openBox<LearningStat>(boxName);
+      return Hive.box<LearningStat>(boxName);
     }
-    return LearningRepository._(box);
+
+    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+      Hive.registerAdapter(LearningStatAdapter());
+    }
+
+    return Hive.openBox<LearningStat>(boxName);
   }
 
   LearningStat get(String wordId) {


### PR DESCRIPTION
## Why
Update `open()` to always return a `Box<LearningStat>` and register the adapter when needed.

## What
- register `LearningStatAdapter` if not registered
- return `Box<LearningStat>` from `LearningRepository.open`

## How
- `dart format` could not be executed because the environment lacks the Dart SDK


------
https://chatgpt.com/codex/tasks/task_e_687a4014377c832aad472e4d41d9b2cf