### PR TITLE
Fix LearningRepository open() return type

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -10,17 +10,18 @@ class LearningRepository {
 
   LearningRepository._(this._box);
 
-  /// Open the Hive box used for stats.
-  static Future<Box<LearningStat>> open() async {
+  /// Open the Hive box used for stats and return a repository.
+  static Future<LearningRepository> open() async {
+    Box<LearningStat> box;
     if (Hive.isBoxOpen(boxName)) {
-      return Hive.box<LearningStat>(boxName);
+      box = Hive.box<LearningStat>(boxName);
+    } else {
+      if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+        Hive.registerAdapter(LearningStatAdapter());
+      }
+      box = await Hive.openBox<LearningStat>(boxName);
     }
-
-    if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
-      Hive.registerAdapter(LearningStatAdapter());
-    }
-
-    return Hive.openBox<LearningStat>(boxName);
+    return LearningRepository._(box);
   }
 
   LearningStat get(String wordId) {


### PR DESCRIPTION
## Why
`flutter build web` failed because `LearningRepository.open()` returned a `Box<LearningStat>` instead of `LearningRepository`, causing type errors.

## What
- revert the `open()` method to return a `LearningRepository` instance

## How
- modified `lib/services/learning_repository.dart`

- [ ] code formatted (dart unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_687a47377fec832aabfd4ff06370dd51