### PR TITLE
Fix test study session flow imports

### DIFF
--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';


### PR DESCRIPTION
## Why
Dart's `Directory` type wasn't imported in `study_session_flow_test.dart`, leading to compilation errors.

## What
- add missing `dart:io` import

## How
- run `dart format` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_687addec4c08832aab3e0de4a059926b