### PR TITLE
Improve WordRepository open logic

### DIFF
--- a/lib/services/word_repository.dart
+++ b/lib/services/word_repository.dart
@@ -14,8 +14,23 @@ class WordRepository {
 
   /// Open the Hive box used for words.
   static Future<WordRepository> open() async {
-    final box = await Hive.openBox<Word>(boxName);
-    return WordRepository._(box);
+    if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
+      Hive.registerAdapter(WordAdapter());
+    }
+
+    if (Hive.isBoxOpen(boxName)) {
+      final box = Hive.box<Word>(boxName);
+      return WordRepository._(box);
+    }
+
+    try {
+      final box = await Hive.openBox<Word>(boxName);
+      return WordRepository._(box);
+    } catch (e) {
+      // ignore: avoid_print
+      print('Failed to open $boxName: $e');
+      rethrow;
+    }
   }
 
   /// Seed words from a bundled JSON file if the box is empty.


### PR DESCRIPTION
## Why
`WordRepository.open()` did not register the adapter or handle already open boxes like other repositories. This could cause errors when multiple services access the box.

## What
- register `WordAdapter` if not yet registered
- check `Hive.isBoxOpen` and re-use existing box
- open the box in a try/catch block with logging, mirroring `LearningRepository.open()`

## How
- updated `open()` implementation in `lib/services/word_repository.dart`

No formatting could be run as `dart` command is unavailable in the environment.


------
https://chatgpt.com/codex/tasks/task_e_687ae04c1c40832abe08824bcffc173c