### PR TITLE
Stop opening boxes in test harness

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -17,32 +17,31 @@ import '../lib/services/word_repository.dart';
 
 final List<Box<dynamic>> _openedBoxes = [];
 
-/// Initialize Hive for tests and open all required boxes.
+/// Initialize Hive for tests.
 Future<Directory> initHiveForTests() async {
   final dir = await Directory.systemTemp.createTemp('hive_test_');
   Hive.init(dir.path);
 
-  // Register all adapters once
   if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
     Hive.registerAdapter(SavedThemeModeAdapter());
   }
   if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
     Hive.registerAdapter(LearningStatAdapter());
   }
-  if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
-    Hive.registerAdapter(WordAdapter());
-  }
   if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
     Hive.registerAdapter(HistoryEntryAdapter());
-  }
-  if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
-    Hive.registerAdapter(QuizStatAdapter());
   }
   if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
     Hive.registerAdapter(SessionLogAdapter());
   }
   if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
     Hive.registerAdapter(ReviewQueueAdapter());
+  }
+  if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
+    Hive.registerAdapter(WordAdapter());
+  }
+  if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
+    Hive.registerAdapter(QuizStatAdapter());
   }
   if (!Hive.isAdapterRegistered(FlashcardStateAdapter().typeId)) {
     Hive.registerAdapter(FlashcardStateAdapter());
@@ -51,44 +50,6 @@ Future<Directory> initHiveForTests() async {
     Hive.registerAdapter(BookmarkAdapter());
   }
 
-  // The boxes we need in every test
-  const boxNames = [
-    settingsBoxName,
-    reviewQueueBoxName,
-    historyBoxName,
-    LearningRepository.boxName,
-    sessionLogBoxName,
-    favoritesBoxName,
-    WordRepository.boxName,
-    bookmarksBoxName,
-    quizStatsBoxName,
-  ];
-
-  for (final name in boxNames) {
-    if (!Hive.isBoxOpen(name)) {
-      if (name == settingsBoxName) {
-        _openedBoxes.add(await Hive.openBox<SavedThemeMode>(name));
-      } else if (name == reviewQueueBoxName) {
-        _openedBoxes.add(await Hive.openBox<ReviewQueue>(name));
-      } else if (name == historyBoxName) {
-        _openedBoxes.add(await Hive.openBox<HistoryEntry>(name));
-      } else if (name == LearningRepository.boxName) {
-        _openedBoxes.add(await Hive.openBox<LearningStat>(name));
-      } else if (name == sessionLogBoxName) {
-        _openedBoxes.add(await Hive.openBox<SessionLog>(name));
-      } else if (name == favoritesBoxName) {
-        _openedBoxes.add(await Hive.openBox<Map>(name));
-      } else if (name == WordRepository.boxName) {
-        _openedBoxes.add(await Hive.openBox<Word>(name));
-      } else if (name == bookmarksBoxName) {
-        _openedBoxes.add(await Hive.openBox<Bookmark>(name));
-      } else if (name == quizStatsBoxName) {
-        _openedBoxes.add(await Hive.openBox<QuizStat>(name));
-      } else {
-        _openedBoxes.add(await Hive.openBox(name));
-      }
-    }
-  }
   return dir;
 }
 


### PR DESCRIPTION
## Summary
- avoid opening boxes in `initHiveForTests`
- register adapters only

## Testing
- `dart format .` *(fails: command not found)*
- `flutter test --concurrency=1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b093cac24832a96e9df50ac9528f2