### PR TITLE
test_harness: register full adapter list

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -11,9 +11,6 @@ import '../lib/models/review_queue.dart';
 import '../lib/models/quiz_stat.dart';
 import '../lib/models/bookmark.dart';
 import '../lib/models/flashcard_state.dart';
-import '../lib/constants.dart';
-import '../lib/services/learning_repository.dart';
-import '../lib/services/word_repository.dart';
 
 final List<Box<dynamic>> _openedBoxes = [];
 
@@ -22,32 +19,22 @@ Future<Directory> initHiveForTests() async {
   final dir = await Directory.systemTemp.createTemp('hive_test_');
   Hive.init(dir.path);
 
-  if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
-    Hive.registerAdapter(SavedThemeModeAdapter());
-  }
-  if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
-    Hive.registerAdapter(LearningStatAdapter());
-  }
-  if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
-    Hive.registerAdapter(HistoryEntryAdapter());
-  }
-  if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
-    Hive.registerAdapter(SessionLogAdapter());
-  }
-  if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
-    Hive.registerAdapter(ReviewQueueAdapter());
-  }
-  if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
-    Hive.registerAdapter(WordAdapter());
-  }
-  if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
-    Hive.registerAdapter(QuizStatAdapter());
-  }
-  if (!Hive.isAdapterRegistered(FlashcardStateAdapter().typeId)) {
-    Hive.registerAdapter(FlashcardStateAdapter());
-  }
-  if (!Hive.isAdapterRegistered(BookmarkAdapter().typeId)) {
-    Hive.registerAdapter(BookmarkAdapter());
+  final adapters = [
+    WordAdapter(),
+    FlashcardStateAdapter(),
+    HistoryEntryAdapter(),
+    SessionLogAdapter(),
+    ReviewQueueAdapter(),
+    BookmarkAdapter(),
+    QuizStatAdapter(),
+    LearningStatAdapter(),
+    SavedThemeModeAdapter(),
+  ];
+
+  for (final adapter in adapters) {
+    if (!Hive.isAdapterRegistered(adapter.typeId)) {
+      Hive.registerAdapter(adapter);
+    }
   }
 
   return dir;


### PR DESCRIPTION
## Summary
- register all adapters in `initHiveForTests`
- remove unused imports

## Testing
- `dart format -o none --set-exit-if-changed test/test_harness.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b51607c5c832aa2aacdf52aa43597