### PR TITLE
Fix hive adapters list type

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -19,7 +19,7 @@ Future<Directory> initHiveForTests() async {
   final dir = await Directory.systemTemp.createTemp('hive_test_');
   Hive.init(dir.path);
 
-  final adapters = [
+  final List<TypeAdapter<dynamic>> adapters = [
     WordAdapter(),
     FlashcardStateAdapter(),
     HistoryEntryAdapter(),


### PR DESCRIPTION
## Why
Ensure Hive adapters list is typed.

## What
- specify `List<TypeAdapter<dynamic>>` for adapters in tests

## How
- N/A (no runtime changes)

Checklist:
- [ ] `dart format --set-exit-if-changed .` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b555eed7c832a812ac5b9b455a9ef