### PR TITLE
Add adapter registration helper

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -19,25 +19,39 @@ Future<Directory> initHiveForTests() async {
   final dir = await Directory.systemTemp.createTemp('hive_test_');
   Hive.init(dir.path);
 
-  final List<TypeAdapter<dynamic>> adapters = [
-    WordAdapter(),
-    FlashcardStateAdapter(),
-    HistoryEntryAdapter(),
-    SessionLogAdapter(),
-    ReviewQueueAdapter(),
-    BookmarkAdapter(),
-    QuizStatAdapter(),
-    LearningStatAdapter(),
-    SavedThemeModeAdapter(),
-  ];
-
-  for (final adapter in adapters) {
-    if (!Hive.isAdapterRegistered(adapter.typeId)) {
-      Hive.registerAdapter(adapter);
-    }
-  }
+  _registerAdapters();
 
   return dir;
+}
+
+void _registerAdapters() {
+  if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
+    Hive.registerAdapter<Word>(WordAdapter());
+  }
+  if (!Hive.isAdapterRegistered(FlashcardStateAdapter().typeId)) {
+    Hive.registerAdapter<FlashcardState>(FlashcardStateAdapter());
+  }
+  if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
+    Hive.registerAdapter<HistoryEntry>(HistoryEntryAdapter());
+  }
+  if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+    Hive.registerAdapter<SessionLog>(SessionLogAdapter());
+  }
+  if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+    Hive.registerAdapter<ReviewQueue>(ReviewQueueAdapter());
+  }
+  if (!Hive.isAdapterRegistered(BookmarkAdapter().typeId)) {
+    Hive.registerAdapter<Bookmark>(BookmarkAdapter());
+  }
+  if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
+    Hive.registerAdapter<QuizStat>(QuizStatAdapter());
+  }
+  if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+    Hive.registerAdapter<LearningStat>(LearningStatAdapter());
+  }
+  if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
+    Hive.registerAdapter<SavedThemeMode>(SavedThemeModeAdapter());
+  }
 }
 
 /// Close and delete all Hive boxes used for tests.


### PR DESCRIPTION
## Summary
- add `_registerAdapters` helper and use it in `initHiveForTests`
- remove previous adapter list loop

## Testing
- `dart format .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b75a0c768832a95973e3c1520dbcd