### PR TITLE
Update Hive adapter registration and test setup

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -24,7 +24,7 @@ class LearningRepository {
   /// 5. `Hive.openBox` が throw する場合は catch してログだけ出す
   static Future<LearningRepository> open() async {
     if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
-      Hive.registerAdapter(LearningStatAdapter());
+      Hive.registerAdapter<LearningStat>(LearningStatAdapter());
     }
 
     if (Hive.isBoxOpen(boxName)) {

--- a/lib/services/word_repository.dart
+++ b/lib/services/word_repository.dart
@@ -15,7 +15,7 @@ class WordRepository {
   /// Open the Hive box used for words.
   static Future<WordRepository> open() async {
     if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
-      Hive.registerAdapter(WordAdapter());
+      Hive.registerAdapter<Word>(WordAdapter());
     }
 
     if (Hive.isBoxOpen(boxName)) {

--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -16,6 +16,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     wordRepo = await WordRepository.open();
     learningRepo = await LearningRepository.open();
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -19,6 +19,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     historyBox = Hive.box<HistoryEntry>(historyBoxName);
     quizBox = Hive.box<QuizStat>(quizStatsBoxName);
     service = HistoryChartService(historyBox, quizBox);

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -13,6 +13,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
   });
 
   tearDownAll(() async {

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -14,6 +14,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     box = Hive.box<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
   });

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -12,6 +12,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     repo = await LearningRepository.open();
   });
 

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -63,6 +63,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     queueBox = Hive.box<ReviewQueue>(reviewQueueBoxName);
     favBox = Hive.box<Map>(favoritesBoxName);
     statBox = Hive.box<LearningStat>(LearningRepository.boxName);

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -14,6 +14,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     box = Hive.box<ReviewQueue>(reviewQueueBoxName);
     service = ReviewQueueService(box);
   });

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -21,6 +21,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     box = Hive.box<SessionLog>(sessionLogBoxName);
     aggregator = SessionAggregator(box);
   });

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -32,6 +32,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     logBox = Hive.box<SessionLog>(sessionLogBoxName);
     statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     boxQueue = Hive.box<ReviewQueue>(reviewQueueBoxName);

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -23,6 +23,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     await Hive.openBox<HistoryEntry>(historyBoxName);
   });

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -11,8 +11,14 @@ import '../lib/models/review_queue.dart';
 import '../lib/models/quiz_stat.dart';
 import '../lib/models/bookmark.dart';
 import '../lib/models/flashcard_state.dart';
+import '../lib/constants.dart';
+import '../lib/services/learning_repository.dart';
+import '../lib/services/word_repository.dart';
 
 final List<Box<dynamic>> _openedBoxes = [];
+
+const wordsBoxName = WordRepository.boxName;
+const learningStatBoxName = LearningRepository.boxName;
 
 /// Initialize Hive for tests.
 Future<Directory> initHiveForTests() async {
@@ -63,4 +69,26 @@ Future<void> closeHiveForTests(Directory dir) async {
   await Hive.close();
   await dir.delete(recursive: true);
   _openedBoxes.clear();
+}
+
+Future<void> openAllBoxes() async {
+  const boxNames = [
+    settingsBoxName,
+    reviewQueueBoxName,
+    historyBoxName,
+    learningStatBoxName,
+    sessionLogBoxName,
+    bookmarksBoxName,
+    wordsBoxName,
+    quizStatsBoxName,
+  ];
+
+  for (final name in boxNames) {
+    if (!Hive.isBoxOpen(name)) {
+      final box = await Hive.openBox(name);
+      _openedBoxes.add(box);
+    } else {
+      _openedBoxes.add(Hive.box(name));
+    }
+  }
 }

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -16,6 +16,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     box = Hive.box<SavedThemeMode>(settingsBoxName);
     notifier = ThemeModeNotifier(box);
     await notifier.load();

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -29,6 +29,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     box = Hive.box<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
     controller = WordHistoryController(service);

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -13,6 +13,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     favBox = Hive.box<Map>(favoritesBoxName);
   });
 

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -11,6 +11,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     repo = await WordRepository.open();
   });
 

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -35,6 +35,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
     await Hive.openBox<HistoryEntry>(historyBoxName);
     box = Hive.box<Bookmark>(bookmarksBoxName);

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -51,6 +51,7 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
+    await openAllBoxes();
     box = Hive.box<Bookmark>(bookmarksBoxName);
   });
 


### PR DESCRIPTION
## Summary
- specify generic type params when registering Hive adapters
- expose helpers for opening boxes in tests
- ensure each test initializes Hive boxes via the helper

## Testing
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_687b78f31c7c832ab5720a3ac1a2cab1