### PR TITLE
hive: add openTypedBox and refactor services to reuse opened boxes

### DIFF
--- a/lib/hive_utils.dart
+++ b/lib/hive_utils.dart
@@ -1,0 +1,10 @@
+import 'package:hive/hive.dart';
+
+/// Open a typed Hive box safely.
+/// If the box is already open, just return the existing instance.
+Future<Box<T>> openTypedBox<T>(String name) async {
+  if (Hive.isBoxOpen(name)) {
+    return Hive.box<T>(name);
+  }
+  return Hive.openBox<T>(name);
+}

--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -1,4 +1,5 @@
 import 'package:hive/hive.dart';
+import 'package:tango/hive_utils.dart';
 
 import '../models/learning_stat.dart';
 
@@ -27,13 +28,8 @@ class LearningRepository {
       Hive.registerAdapter<LearningStat>(LearningStatAdapter());
     }
 
-    if (Hive.isBoxOpen(boxName)) {
-      final box = Hive.box<LearningStat>(boxName);
-      return LearningRepository._(box);
-    }
-
     try {
-      final box = await Hive.openBox<LearningStat>(boxName);
+      final box = await openTypedBox<LearningStat>(boxName);
       return LearningRepository._(box);
     } catch (e) {
       // ignore: avoid_print

--- a/lib/services/word_repository.dart
+++ b/lib/services/word_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:hive/hive.dart';
+import 'package:tango/hive_utils.dart';
 
 import '../models/word.dart';
 
@@ -18,13 +19,8 @@ class WordRepository {
       Hive.registerAdapter<Word>(WordAdapter());
     }
 
-    if (Hive.isBoxOpen(boxName)) {
-      final box = Hive.box<Word>(boxName);
-      return WordRepository._(box);
-    }
-
     try {
-      final box = await Hive.openBox<Word>(boxName);
+      final box = await openTypedBox<Word>(boxName);
       return WordRepository._(box);
     } catch (e) {
       // ignore: avoid_print

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -24,8 +24,6 @@ void main() {
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
     await openAllBoxes();
-    await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
-    await Hive.openBox<HistoryEntry>(historyBoxName);
   });
 
   tearDownAll(() async {

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -36,8 +36,6 @@ void main() {
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
     await openAllBoxes();
-    await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
-    await Hive.openBox<HistoryEntry>(historyBoxName);
     box = Hive.box<Bookmark>(bookmarksBoxName);
   });
 


### PR DESCRIPTION
## Why
Avoid collisions when opening Hive boxes multiple times.

## What
- add `openTypedBox` utility
- refactor `LearningRepository` and `WordRepository` to use it
- clean up redundant `Hive.openBox` calls in tests

## How
- new `lib/hive_utils.dart`
- updated services to call `openTypedBox`
- removed duplicate box openings in tests



------
https://chatgpt.com/codex/tasks/task_e_687b824dbfa0832aa491777b3cb80f82