### PR TITLE
Fix duplicate Hive box opening in tests

### DIFF
--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -16,7 +16,6 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
     wordRepo = await WordRepository.open();
     learningRepo = await LearningRepository.open();
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -19,7 +19,12 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(historyBoxName)) {
+      await Hive.openBox<HistoryEntry>(historyBoxName);
+    }
+    if (!Hive.isBoxOpen(quizStatsBoxName)) {
+      await Hive.openBox<QuizStat>(quizStatsBoxName);
+    }
     historyBox = Hive.box<HistoryEntry>(historyBoxName);
     quizBox = Hive.box<QuizStat>(quizStatsBoxName);
     service = HistoryChartService(historyBox, quizBox);

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -14,7 +14,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(historyBoxName)) {
+      await Hive.openBox<HistoryEntry>(historyBoxName);
+    }
     box = Hive.box<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
   });

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -12,7 +12,6 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
     repo = await LearningRepository.open();
   });
 

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -63,7 +63,18 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(reviewQueueBoxName)) {
+      await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+    }
+    if (!Hive.isBoxOpen(favoritesBoxName)) {
+      await Hive.openBox<Map>(favoritesBoxName);
+    }
+    if (!Hive.isBoxOpen(LearningRepository.boxName)) {
+      await Hive.openBox<LearningStat>(LearningRepository.boxName);
+    }
+    if (!Hive.isBoxOpen(WordRepository.boxName)) {
+      await Hive.openBox<Word>(WordRepository.boxName);
+    }
     queueBox = Hive.box<ReviewQueue>(reviewQueueBoxName);
     favBox = Hive.box<Map>(favoritesBoxName);
     statBox = Hive.box<LearningStat>(LearningRepository.boxName);

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -14,7 +14,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(reviewQueueBoxName)) {
+      await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+    }
     box = Hive.box<ReviewQueue>(reviewQueueBoxName);
     service = ReviewQueueService(box);
   });

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -21,7 +21,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(sessionLogBoxName)) {
+      await Hive.openBox<SessionLog>(sessionLogBoxName);
+    }
     box = Hive.box<SessionLog>(sessionLogBoxName);
     aggregator = SessionAggregator(box);
   });

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -32,7 +32,15 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(sessionLogBoxName)) {
+      await Hive.openBox<SessionLog>(sessionLogBoxName);
+    }
+    if (!Hive.isBoxOpen(LearningRepository.boxName)) {
+      await Hive.openBox<LearningStat>(LearningRepository.boxName);
+    }
+    if (!Hive.isBoxOpen(reviewQueueBoxName)) {
+      await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+    }
     logBox = Hive.box<SessionLog>(sessionLogBoxName);
     statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     boxQueue = Hive.box<ReviewQueue>(reviewQueueBoxName);

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -16,7 +16,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(settingsBoxName)) {
+      await Hive.openBox<SavedThemeMode>(settingsBoxName);
+    }
     box = Hive.box<SavedThemeMode>(settingsBoxName);
     notifier = ThemeModeNotifier(box);
     await notifier.load();

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -29,7 +29,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(historyBoxName)) {
+      await Hive.openBox<HistoryEntry>(historyBoxName);
+    }
     box = Hive.box<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
     controller = WordHistoryController(service);

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -13,7 +13,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(favoritesBoxName)) {
+      await Hive.openBox<Map>(favoritesBoxName);
+    }
     favBox = Hive.box<Map>(favoritesBoxName);
   });
 

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -11,7 +11,6 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
     repo = await WordRepository.open();
   });
 

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -35,7 +35,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(bookmarksBoxName)) {
+      await Hive.openBox<Bookmark>(bookmarksBoxName);
+    }
     box = Hive.box<Bookmark>(bookmarksBoxName);
   });
 

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -51,7 +51,9 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    await openAllBoxes();
+    if (!Hive.isBoxOpen(bookmarksBoxName)) {
+      await Hive.openBox<Bookmark>(bookmarksBoxName);
+    }
     box = Hive.box<Bookmark>(bookmarksBoxName);
   });
 


### PR DESCRIPTION
## Why
Repeated `openAllBoxes()` in tests was causing "already open" errors.

## What
- removed `openAllBoxes()` calls from tests
- opened required boxes with `Hive.isBoxOpen` guards

## How
- edited multiple test files
- `dart format` could not run because Dart is missing in the environment

------
https://chatgpt.com/codex/tasks/task_e_687d8ab1a6f8832ab82c0a3d3147d09a