### PR TITLE
Fix HistoryEntry import in test_harness

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -5,7 +5,7 @@ import 'package:hive/hive.dart';
 import 'package:tango/models/word.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/models/saved_theme_mode.dart';
-import 'package:tango/models/history_entry.dart';
+import 'package:tango/history_entry_model.dart';
 import 'package:tango/models/review_queue.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/models/bookmark.dart';


### PR DESCRIPTION
## Summary
- fix HistoryEntry import path in `test/test_harness.dart`

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687da8c8bf34832ab43c09e05f9b17e6