### PR TITLE
fix: resolve setUpAll import collisions

### DIFF
--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -6,7 +6,7 @@ import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/word_repository.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/flashcard_loader.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -9,7 +9,7 @@ import 'package:tango/models/quiz_stat.dart';
 import 'package:tango/services/history_chart_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/learning_history_detail_screen.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -6,7 +6,7 @@ import 'package:hive/hive.dart';
 import 'package:tango/history_screen.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -5,7 +5,7 @@ import 'package:hive/hive.dart';
 import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/history_service.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/learning_repository.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -18,7 +18,7 @@ import 'package:tango/flashcard_repository.dart';
 import 'package:tango/flashcard_repository_provider.dart';
 import 'package:tango/services/flashcard_loader.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 class _FakeLoader implements FlashcardLoader {
   final List<Flashcard> cards;

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -5,7 +5,7 @@ import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/models/review_queue.dart';
 import 'package:tango/services/review_queue_service.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -5,7 +5,7 @@ import 'package:hive/hive.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/services/aggregator.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -9,7 +9,7 @@ import 'package:tango/study_session_controller.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/services/review_queue_service.dart';
 import 'package:tango/services/learning_repository.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -16,7 +16,7 @@ import 'package:tango/flashcard_repository_provider.dart';
 import 'package:tango/study_session_controller.dart';
 import 'package:tango/study_start_sheet.dart';
 import 'fakes/fake_flashcard_repository.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:hive/hive.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart' as ft;
 
 import 'package:tango/models/word.dart';
 import 'package:tango/models/learning_stat.dart';
@@ -89,7 +89,7 @@ Future<void> openAllBoxes() async {
   ]);
 }
 
-setUpAll(() async {
+ft.setUpAll(() async {
   Hive.initMemory();
 
   _register<Word>(WordAdapter());

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -7,7 +7,7 @@ import 'package:hive/hive.dart';
 import 'package:tango/theme_mode_provider.dart';
 import 'package:tango/models/saved_theme_mode.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -7,7 +7,7 @@ import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/history_service.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 Flashcard _card(String id) => Flashcard(
       id: id,

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -5,7 +5,7 @@ import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/word_list_query.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/word.dart';
 import 'package:tango/services/word_repository.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 void main() {
   late Directory hiveTempDir;

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -11,7 +11,7 @@ import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/bookmark_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/wordbook_screen.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 Flashcard _card(int i) => Flashcard(
       id: '$i',

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -9,7 +9,7 @@ import 'package:tango/models/bookmark.dart';
 import 'package:tango/services/bookmark_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/wordbook_screen.dart';
-import 'test_harness.dart';
+import 'test_harness.dart' hide setUpAll;
 
 Flashcard _card(String id, String term) => Flashcard(
       id: id,


### PR DESCRIPTION
## Why
- avoid name clashes with `setUpAll` when importing the test harness

## What
- alias `flutter_test` import in `test_harness.dart`
- hide `setUpAll` when importing the harness in each test file

## How
- edited `test/test_harness.dart`
- updated harness imports across 16 tests

No formatting was run as the environment lacks the `dart` tool.

------
https://chatgpt.com/codex/tasks/task_e_687e266ac99c832aaae18695f4450b30