### PR TITLE
fix: correct setUpAll block syntax

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:hive/hive.dart';
-import 'package:flutter_test/flutter_test.dart' as ft;
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:tango/models/word.dart';
 import 'package:tango/models/learning_stat.dart';
@@ -89,7 +89,7 @@ Future<void> openAllBoxes() async {
   ]);
 }
 
-ft.setUpAll(() async {
+setUpAll(() async {
   Hive.initMemory();
 
   _register<Word>(WordAdapter());


### PR DESCRIPTION
## Summary
- fix the setUpAll initialization syntax in test harness

## Testing
- `dart format test/test_harness.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e2b277fb4832a820cbd4099b9bcf3