### PR TITLE
Fix test harness syntax

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -75,7 +75,6 @@ Future<void> openAllBoxes() async {
     _register<Bookmark>(BookmarkAdapter());
     _register<QuizStat>(QuizStatAdapter());
     _register<FlashcardState>(FlashcardStateAdapter());
-  }
 
   await Future.wait([
     Hive.openBox<SavedThemeMode>('settings_box'),


### PR DESCRIPTION
## Summary
- clean up extra brace in `openAllBoxes`

## Testing
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e30686620832ab83cdc9fab9f29f2