### PR TITLE
Fix remaining Hive & UI issues

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -27,9 +27,10 @@ class LearningRepository {
     if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
       Hive.registerAdapter<LearningStat>(LearningStatAdapter());
     }
-
     try {
-      final box = await openTypedBox<LearningStat>(boxName);
+      final box = Hive.isBoxOpen(boxName)
+          ? Hive.box<LearningStat>(boxName)
+          : await Hive.openBox<LearningStat>(boxName);
       return LearningRepository._(box);
     } catch (e) {
       // ignore: avoid_print

--- a/lib/services/review_queue_service.dart
+++ b/lib/services/review_queue_service.dart
@@ -2,12 +2,23 @@ import 'package:hive/hive.dart';
 
 import '../models/review_queue.dart';
 import '../constants.dart';
+import '../hive_utils.dart';
 
 class ReviewQueueService {
   final Box<ReviewQueue> _box;
 
+  ReviewQueueService._(this._box);
+
   ReviewQueueService([Box<ReviewQueue>? box])
       : _box = box ?? Hive.box<ReviewQueue>(reviewQueueBoxName);
+
+  static Future<ReviewQueueService> open() async {
+    if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+      Hive.registerAdapter<ReviewQueue>(ReviewQueueAdapter());
+    }
+    final box = await openTypedBox<ReviewQueue>(reviewQueueBoxName);
+    return ReviewQueueService._(box);
+  }
 
   ReviewQueue get _queue => _box.get('queue') ?? ReviewQueue();
 

--- a/lib/services/word_repository.dart
+++ b/lib/services/word_repository.dart
@@ -18,9 +18,10 @@ class WordRepository {
     if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
       Hive.registerAdapter<Word>(WordAdapter());
     }
-
     try {
-      final box = await openTypedBox<Word>(boxName);
+      final box = Hive.isBoxOpen(boxName)
+          ? Hive.box<Word>(boxName)
+          : await Hive.openBox<Word>(boxName);
       return WordRepository._(box);
     } catch (e) {
       // ignore: avoid_print

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -9,6 +9,7 @@ import 'package:tango/models/quiz_stat.dart';
 import 'package:tango/services/history_chart_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/learning_history_detail_screen.dart';
+import 'package:tango/hive_utils.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
@@ -19,14 +20,8 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(historyBoxName)) {
-      await Hive.openBox<HistoryEntry>(historyBoxName);
-    }
-    if (!Hive.isBoxOpen(quizStatsBoxName)) {
-      await Hive.openBox<QuizStat>(quizStatsBoxName);
-    }
-    historyBox = Hive.box<HistoryEntry>(historyBoxName);
-    quizBox = Hive.box<QuizStat>(quizStatsBoxName);
+    historyBox = await openTypedBox<HistoryEntry>(historyBoxName);
+    quizBox = await openTypedBox<QuizStat>(quizStatsBoxName);
     service = HistoryChartService(historyBox, quizBox);
   });
 

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -14,11 +14,8 @@ void main() {
 
   setUpAll(() async {
     hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(reviewQueueBoxName)) {
-      await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
-    }
+    service = await ReviewQueueService.open();
     box = Hive.box<ReviewQueue>(reviewQueueBoxName);
-    service = ReviewQueueService(box);
   });
 
   tearDown(() async {

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -35,12 +35,8 @@ void main() {
     if (!Hive.isBoxOpen(sessionLogBoxName)) {
       await Hive.openBox<SessionLog>(sessionLogBoxName);
     }
-    if (!Hive.isBoxOpen(LearningRepository.boxName)) {
-      await Hive.openBox<LearningStat>(LearningRepository.boxName);
-    }
-    if (!Hive.isBoxOpen(reviewQueueBoxName)) {
-      await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
-    }
+    await LearningRepository.open();
+    await ReviewQueueService.open();
     logBox = Hive.box<SessionLog>(sessionLogBoxName);
     statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     boxQueue = Hive.box<ReviewQueue>(reviewQueueBoxName);

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -15,6 +15,8 @@ import 'package:tango/models/quiz_stat.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/word_repository.dart';
+import 'package:tango/services/review_queue_service.dart';
+import 'package:tango/hive_utils.dart';
 
 /// Opens the Hive boxes that unit tests expect.
 Future<void> _openTestBoxes() async {
@@ -79,14 +81,14 @@ Future<void> openAllBoxes() async {
   }
 
   await Future.wait([
-    Hive.openBox<SavedThemeMode>('settings_box'),
-    Hive.openBox<ReviewQueue>('review_queue_box_v1'),
-    Hive.openBox<HistoryEntry>('history_box_v2'),
-    Hive.openBox<LearningStat>('learning_stat_box_v1'),
-    Hive.openBox<SessionLog>('session_log_box_v1'),
-    Hive.openBox<Bookmark>('bookmarks_box_v1'),
-    Hive.openBox<Word>('words_box_v1'),
-    Hive.openBox<QuizStat>('quiz_stats_box_v1'),
+    openTypedBox<SavedThemeMode>('settings_box'),
+    ReviewQueueService.open(),
+    openTypedBox<HistoryEntry>('history_box_v2'),
+    LearningRepository.open(),
+    openTypedBox<SessionLog>('session_log_box_v1'),
+    openTypedBox<Bookmark>('bookmarks_box_v1'),
+    WordRepository.open(),
+    openTypedBox<QuizStat>('quiz_stats_box_v1'),
   ]);
 }
 


### PR DESCRIPTION
## Why
Resolve the last failing tests and improve box handling.

## What
- fixed repository open methods to safely reuse Hive boxes
- added `open()` to `ReviewQueueService`
- updated unit tests to rely on repository/service `open()` helpers
- minor syntax cleanup

## How
- `dart format` *(fails: dart not installed)*
- `flutter test --concurrency=1` *(fails: flutter not installed)*


------
https://chatgpt.com/codex/tasks/task_e_687ee7eb7ee8832a80f23c0be9a162ef