### PR TITLE
Use hive_test for test setup

### DIFF
--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -18,4 +18,6 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       - name: Run tests
-        run: flutter test --coverage
+        run: flutter test --coverage --concurrency=1
+        env:
+          CI: "true"

--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/word.dart';
@@ -9,21 +8,17 @@ import 'package:tango/services/flashcard_loader.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late WordRepository wordRepo;
   late LearningRepository learningRepo;
   late HiveFlashcardLoader loader;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
     wordRepo = await WordRepository.open();
     learningRepo = await LearningRepository.open();
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
+  tearDownAll(() async {});
 
   test('loads flashcards with stats merged', () async {
     await wordRepo.add(Word(

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,13 +12,11 @@ import 'package:tango/hive_utils.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late Box<HistoryEntry> historyBox;
   late Box<QuizStat> quizBox;
   late HistoryChartService service;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
     historyBox = await openTypedBox<HistoryEntry>(historyBoxName);
     quizBox = await openTypedBox<QuizStat>(quizStatsBoxName);
     service = HistoryChartService(historyBox, quizBox);
@@ -30,9 +27,7 @@ void main() {
     await quizBox.clear();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
+  tearDownAll(() async {});
 
   test('calculates chart data', () async {
     final now = DateTime.now();

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,16 +8,12 @@ import 'package:tango/constants.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
     await openAllBoxes();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
+  tearDownAll(() async {});
 
   testWidgets('shows empty message when no data', (tester) async {
     await tester.pumpWidget(const ProviderScope(

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -8,22 +7,14 @@ import 'package:tango/constants.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late Box<HistoryEntry> box;
   late HistoryService service;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(historyBoxName)) {
-      await Hive.openBox<HistoryEntry>(historyBoxName);
-    }
-    box = Hive.box<HistoryEntry>(historyBoxName);
+    box = await openTypedBox<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
 
   test('adds unique entries', () async {
     await service.addView('1');

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -7,17 +6,12 @@ import 'package:tango/services/learning_repository.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late LearningRepository repo;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
     repo = await LearningRepository.open();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
 
   test('stores and retrieves stats', () async {
     await repo.markReviewed('1');

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -29,7 +28,6 @@ class _FakeLoader implements FlashcardLoader {
 }
 
 void main() {
-  late Directory hiveTempDir;
   late Box<ReviewQueue> queueBox;
   late Box<Map> favBox;
   late Box<LearningStat> statBox;
@@ -62,23 +60,10 @@ void main() {
       );
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(reviewQueueBoxName)) {
-      await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
-    }
-    if (!Hive.isBoxOpen(favoritesBoxName)) {
-      await Hive.openBox<Map>(favoritesBoxName);
-    }
-    if (!Hive.isBoxOpen(LearningRepository.boxName)) {
-      await Hive.openBox<LearningStat>(LearningRepository.boxName);
-    }
-    if (!Hive.isBoxOpen(WordRepository.boxName)) {
-      await Hive.openBox<Word>(WordRepository.boxName);
-    }
-    queueBox = Hive.box<ReviewQueue>(reviewQueueBoxName);
-    favBox = Hive.box<Map>(favoritesBoxName);
-    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
-    wordBox = Hive.box<Word>(WordRepository.boxName);
+    queueBox = await openTypedBox<ReviewQueue>(reviewQueueBoxName);
+    favBox = await openTypedBox<Map>(favoritesBoxName);
+    statBox = await openTypedBox<LearningStat>(LearningRepository.boxName);
+    wordBox = await openTypedBox<Word>(WordRepository.boxName);
     await wordBox.put('0', _word('0'));
     service = ReviewQueueService(queueBox);
     repo = FlashcardRepository(loader: _FakeLoader([_card('0')]));
@@ -91,9 +76,7 @@ void main() {
     await wordBox.clear();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
+  tearDownAll(() async {});
 
   testWidgets('weak button disabled when queue empty', (tester) async {
     await tester.pumpWidget(

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
@@ -8,12 +6,10 @@ import 'package:tango/services/review_queue_service.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late Box<ReviewQueue> box;
   late ReviewQueueService service;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
     service = await ReviewQueueService.open();
     box = Hive.box<ReviewQueue>(reviewQueueBoxName);
   });
@@ -22,9 +18,6 @@ void main() {
     await box.clear();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
 
   test('push limits queue to 200 and drops oldest', () async {
     for (var i = 0; i < 205; i++) {

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -8,7 +7,6 @@ import 'package:tango/constants.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late Box<SessionLog> box;
   late SessionAggregator aggregator;
 
@@ -20,17 +18,11 @@ void main() {
       );
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(sessionLogBoxName)) {
-      await Hive.openBox<SessionLog>(sessionLogBoxName);
-    }
-    box = Hive.box<SessionLog>(sessionLogBoxName);
+    box = await openTypedBox<SessionLog>(sessionLogBoxName);
     aggregator = SessionAggregator(box);
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
+  tearDownAll(() async {});
 
   test('aggregates and streak', () async {
     final now = DateTime.now();

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/flashcard_model.dart';
@@ -12,7 +11,6 @@ import 'package:tango/services/learning_repository.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late Box<SessionLog> logBox;
   late Box<LearningStat> statBox;
   late Box<ReviewQueue> boxQueue;
@@ -31,10 +29,7 @@ void main() {
       );
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(sessionLogBoxName)) {
-      await Hive.openBox<SessionLog>(sessionLogBoxName);
-    }
+    await openTypedBox<SessionLog>(sessionLogBoxName);
     await LearningRepository.open();
     await ReviewQueueService.open();
     logBox = Hive.box<SessionLog>(sessionLogBoxName);
@@ -43,9 +38,6 @@ void main() {
     controller = StudySessionController(logBox, ReviewQueueService(boxQueue));
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
 
   test('progresses through states', () async {
     await controller.start(words: [_card('1')], targetWords: 1, targetMinutes: 0);

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -19,16 +17,11 @@ import 'fakes/fake_flashcard_repository.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
     await openAllBoxes();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
 
   Flashcard _card(String id) => Flashcard(
         id: id,

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -1,10 +1,9 @@
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:hive_test/hive_test.dart';
 
-// ★ 既存 util だけをインポート（重複定義を排除）
 import 'package:tango/hive_utils.dart' show openTypedBox;
+export 'package:tango/hive_utils.dart' show openTypedBox;
 
 import 'package:tango/models/word.dart';
 import 'package:tango/models/learning_stat.dart';
@@ -19,16 +18,6 @@ import 'package:tango/constants.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/word_repository.dart';
 
-/// Opens the Hive boxes that unit tests expect.
-Future<void> _openTestBoxes() async {
-  await Future.wait([
-    Hive.openBox<dynamic>('bookmark_box'),
-    Hive.openBox<dynamic>('history_box_v2'),
-  ]);
-}
-
-final List<Box<dynamic>> _openedBoxes = [];
-
 const wordsBoxName = WordRepository.boxName;
 const learningStatBoxName = LearningRepository.boxName;
 
@@ -38,72 +27,36 @@ void _register<T>(TypeAdapter<T> adapter) {
   }
 }
 
-/// Initialize Hive for tests.
-Future<Directory> initHiveForTests() async {
-  final dir = await Directory.systemTemp.createTemp('hive_test_');
-  Hive.init(dir.path);
-
-  _register<Word>(WordAdapter());
-  _register<LearningStat>(LearningStatAdapter());
-  _register<SavedThemeMode>(SavedThemeModeAdapter());
-  _register<HistoryEntry>(HistoryEntryAdapter());
-  _register<ReviewQueue>(ReviewQueueAdapter());
-  _register<SessionLog>(SessionLogAdapter());
-  _register<Bookmark>(BookmarkAdapter());
-
-  return dir;
-}
-
-/// Close and delete all Hive boxes used for tests.
-Future<void> closeHiveForTests(Directory dir) async {
-  for (final box in _openedBoxes.where((b) => b.isOpen)) {
-    await box.close();
-    await box.deleteFromDisk();
-  }
-  await Hive.close();
-  await dir.delete(recursive: true);
-  _openedBoxes.clear();
+void _registerAdapters() {
+  _register(WordAdapter());
+  _register(LearningStatAdapter());
+  _register(SavedThemeModeAdapter());
+  _register(HistoryEntryAdapter());
+  _register(ReviewQueueAdapter());
+  _register(SessionLogAdapter());
+  _register(BookmarkAdapter());
+  _register(QuizStatAdapter());
+  _register(FlashcardStateAdapter());
 }
 
 Future<void> openAllBoxes() async {
-  if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
-    // 念のため。テスト前に必ず登録される想定だがダブルチェック。
-    _register<Word>(WordAdapter());
-    _register<LearningStat>(LearningStatAdapter());
-    _register<SavedThemeMode>(SavedThemeModeAdapter());
-    _register<HistoryEntry>(HistoryEntryAdapter());
-    _register<ReviewQueue>(ReviewQueueAdapter());
-    _register<SessionLog>(SessionLogAdapter());
-    _register<Bookmark>(BookmarkAdapter());
-    _register<QuizStat>(QuizStatAdapter());
-    _register<FlashcardState>(FlashcardStateAdapter());
-  }
-
   await Future.wait([
-    openTypedBox<SavedThemeMode>('settings_box'),
-    openTypedBox<ReviewQueue>('review_queue_box_v1'),
-    openTypedBox<HistoryEntry>('history_box_v2'),
-    openTypedBox<LearningStat>('learning_stat_box_v1'),
-    openTypedBox<SessionLog>('session_log_box_v1'),
-    openTypedBox<Bookmark>('bookmarks_box_v1'),
-    openTypedBox<Word>('words_box_v1'),
-    openTypedBox<QuizStat>('quiz_stats_box_v1'),
+    openTypedBox<SavedThemeMode>(settingsBoxName),
+    openTypedBox<ReviewQueue>(reviewQueueBoxName),
+    openTypedBox<HistoryEntry>(historyBoxName),
+    openTypedBox<LearningStat>(learningStatBoxName),
+    openTypedBox<SessionLog>(sessionLogBoxName),
+    openTypedBox<Bookmark>(bookmarksBoxName),
+    openTypedBox<Word>(wordsBoxName),
+    openTypedBox<QuizStat>(quizStatsBoxName),
   ]);
 }
 
-// ===== test bootstrap =====
 setUpAll(() async {
-  Hive.initMemory();
+  await setUpTestHive();
+  _registerAdapters();
+});
 
-  _register<Word>(WordAdapter());
-  _register<LearningStat>(LearningStatAdapter());
-  _register<SavedThemeMode>(SavedThemeModeAdapter());
-  _register<HistoryEntry>(HistoryEntryAdapter());
-  _register<ReviewQueue>(ReviewQueueAdapter());
-  _register<SessionLog>(SessionLogAdapter());
-  _register<Bookmark>(BookmarkAdapter());
-  _register<QuizStat>(QuizStatAdapter());
-  _register<FlashcardState>(FlashcardStateAdapter());
-
-  await _openTestBoxes();
+tearDownAll(() async {
+  await tearDownTestHive();
 });

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,16 +9,11 @@ import 'package:tango/constants.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late Box<SavedThemeMode> box;
   late ThemeModeNotifier notifier;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(settingsBoxName)) {
-      await Hive.openBox<SavedThemeMode>(settingsBoxName);
-    }
-    box = Hive.box<SavedThemeMode>(settingsBoxName);
+    box = await openTypedBox<SavedThemeMode>(settingsBoxName);
     notifier = ThemeModeNotifier(box);
     await notifier.load();
   });
@@ -28,9 +22,6 @@ void main() {
     await box.clear();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
 
   test('initial value system', () {
     expect(notifier.state, ThemeMode.system);

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
@@ -22,17 +21,12 @@ Flashcard _card(String id) => Flashcard(
     );
 
 void main() {
-  late Directory hiveTempDir;
   late Box<HistoryEntry> box;
   late HistoryService service;
   late WordHistoryController controller;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(historyBoxName)) {
-      await Hive.openBox<HistoryEntry>(historyBoxName);
-    }
-    box = Hive.box<HistoryEntry>(historyBoxName);
+    box = await openTypedBox<HistoryEntry>(historyBoxName);
     service = HistoryService(box);
     controller = WordHistoryController(service);
   });
@@ -43,7 +37,6 @@ void main() {
 
   tearDownAll(() async {
     controller.dispose();
-    await closeHiveForTests(hiveTempDir);
   });
 
   test('records view after delay', () {

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -1,27 +1,10 @@
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/word_list_query.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
-  late Box<Map> favBox;
-
-  setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(favoritesBoxName)) {
-      await Hive.openBox<Map>(favoritesBoxName);
-    }
-    favBox = Hive.box<Map>(favoritesBoxName);
-  });
-
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
   final card1 = Flashcard(
     id: '1',
     term: 'a',

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/word.dart';
@@ -6,11 +5,9 @@ import 'package:tango/services/word_repository.dart';
 import 'test_harness.dart' hide setUpAll;
 
 void main() {
-  late Directory hiveTempDir;
   late WordRepository repo;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
     repo = await WordRepository.open();
   });
 
@@ -18,9 +15,6 @@ void main() {
     await Hive.box<Word>(WordRepository.boxName).clear();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
 
   test('adds and fetches word', () async {
     final word = Word(

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -30,20 +29,12 @@ Flashcard _card(int i) => Flashcard(
     );
 
 void main() {
-  late Directory hiveTempDir;
   late Box<Bookmark> box;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(bookmarksBoxName)) {
-      await Hive.openBox<Bookmark>(bookmarksBoxName);
-    }
-    box = Hive.box<Bookmark>(bookmarksBoxName);
+    box = await openTypedBox<Bookmark>(bookmarksBoxName);
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
   testWidgets('shows current page indicator in AppBar', (tester) async {
     final cards = List.generate(861, (i) => _card(i + 1));
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 77});

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -46,24 +45,17 @@ Flashcard _cardWithRelated(String id, String term, List<String> related) =>
     );
 
 void main() {
-  late Directory hiveTempDir;
   late Box<Bookmark> box;
 
   setUpAll(() async {
-    hiveTempDir = await initHiveForTests();
-    if (!Hive.isBoxOpen(bookmarksBoxName)) {
-      await Hive.openBox<Bookmark>(bookmarksBoxName);
-    }
-    box = Hive.box<Bookmark>(bookmarksBoxName);
+    box = await openTypedBox<Bookmark>(bookmarksBoxName);
   });
 
   tearDown(() async {
     await box.clear();
   });
 
-  tearDownAll(() async {
-    await closeHiveForTests(hiveTempDir);
-  });
+  tearDownAll(() async {});
   final cards = [_card('1', 'a'), _card('2', 'b')];
 
   testWidgets('restores bookmark page', (tester) async {


### PR DESCRIPTION
## Summary
- rely on `hive_test` for in-memory Hive setup
- reexport `openTypedBox` from the harness
- update all unit tests to drop manual temp directory handling
- run tests in CI with concurrency 1

## Testing
- `dart format` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b7083a90832ab52f3324e4cf7b37