### PR TITLE
Fix syntax errors in wordbook screen

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -319,6 +319,7 @@ class WordbookScreenState extends State<WordbookScreen> {
                       final index = v.round() - 1;
                       _jumpToPage(index);
                     },
+                  ),
         Positioned.fill(
           child: IgnorePointer(
             ignoring: !_showControls,
@@ -636,10 +637,6 @@ class _SearchSheetState extends State<_SearchSheet> {
               child: IconButton(
                 icon: const Icon(Icons.close),
                 onPressed: () => Navigator.of(context).pop(),
-                inputFormatters: [
-                  FilteringTextInputFormatter.deny(RegExp(r'[<>/\\]')),
-                ],
-                onChanged: (v) => setState(() => _query = v),
               ),
             ),
             Flexible(


### PR DESCRIPTION
## Summary
- close a dangling `Slider` call in `WordbookScreen`
- remove unsupported parameters from close button in search sheet

## Testing
- `dart format --set-exit-if-changed lib/wordbook_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688384e727d4832a9a7bb4a8887f1f30