### PR TITLE
fix: remove duplicate hive_test entry

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,6 @@ dev_dependencies:
   hive_test: ^1.0.0      # in-memory Hive for tests
   hive_generator: ^2.0.1 # Hiveオブジェクトを生成するために必要
   build_runner: ^2.4.0   # コードジェネレータを実行するために必要
-  hive_test: ^1.0.0
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your


### PR DESCRIPTION
## Why
GitHub Actions failed because `pubspec.yaml` contained a duplicate `hive_test` entry.

## What
- remove the duplicate line from `pubspec.yaml`

## How
- edited YAML accordingly

Attempted to run `dart format`, but `dart` was not available in the environment.

------
https://chatgpt.com/codex/tasks/task_e_68838a77d8ec832ab7e1d3c6320b7556