### PR TITLE
fix: resolve Dart syntax errors

### DIFF
--- a/lib/wordbook_screen.dart
+++ b/lib/wordbook_screen.dart
@@ -166,17 +166,12 @@ class WordbookScreenState extends State<WordbookScreen> {
     );
     if (!mounted) return;
     if (result != null) {
-      _jumpToPage(result);
+      _pageController.jumpToPage(result);
+      setState(() => _currentIndex = result);
+      _pushHistory(result);
+      _saveBookmark(result);
+      widget.onIndexChanged?.call(result);
     }
-      if (result != null) {
-        _pageController.jumpToPage(result);
-        setState(() {
-          _currentIndex = result;
-        });
-        _pushHistory(result);
-        _saveBookmark(result);
-        widget.onIndexChanged?.call(result);
-      }
   }
 
   void _goBack() {
@@ -254,7 +249,6 @@ class WordbookScreenState extends State<WordbookScreen> {
         ],
       ),
           ),
-        ),
         // Tappable areas for page navigation on phones
         if (widget.flashcards.length > 1 && !_showControls) ...[
           Positioned(
@@ -661,4 +655,3 @@ class _SearchSheetState extends State<_SearchSheet> {
 
 }
               
-// minor change to trigger CI

--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -22,7 +22,6 @@ void main() {
   setUp(() async {
     dir = await Directory.systemTemp.createTemp();
     Hive.init(dir.path);
-    final List<TypeAdapter<dynamic>> adapters = [
     final adapters = <TypeAdapter<dynamic>>[
       HistoryEntryAdapter(),
       WordAdapter(),
@@ -56,7 +55,7 @@ void main() {
     ];
     for (final name in boxes) {
       if (await Hive.boxExists(name)) {
-    await Hive.deleteBoxFromDisk(name);
+        await Hive.deleteBoxFromDisk(name);
       }
     }
     await Hive.close();

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -86,17 +86,6 @@ void main() {
               ReviewQueueService(queueBox),
             ),
           ),
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          studySessionControllerProvider.overrideWith((ref) {
-            final logBox = Hive.box<SessionLog>(sessionLogBoxName);
-            final queueBox = Hive.box<ReviewQueue>(reviewQueueBoxName);
-            return StudySessionController(logBox, ReviewQueueService(queueBox));
-          }),
-          flashcardRepositoryProvider.overrideWithValue(
-            FakeFlashcardRepository([_card('0')]),
-          )
         ],
         child: MaterialApp(
           home: Builder(


### PR DESCRIPTION
## Summary
- fix unbalanced widgets in `WordbookScreen`
- remove duplicate adapter setup in box initializer test
- clean up study session flow test setup

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884084fbcf0832a8bac39119d756165