### PR TITLE
Fix test harness parsing errors

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -1,12 +1,9 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart' as ft;
 import 'package:hive/hive.dart';
-import 'package:hive_test/hive_test.dart';
 
-// Re-export openTypedBox for test files
 import 'package:tango/hive_utils.dart' show openTypedBox;
 export 'package:tango/hive_utils.dart' show openTypedBox;
 
-// Model adapters
 import 'package:tango/models/word.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/models/saved_theme_mode.dart';
@@ -17,24 +14,19 @@ import 'package:tango/models/bookmark.dart';
 import 'package:tango/models/flashcard_state.dart';
 import 'package:tango/models/quiz_stat.dart';
 
-// Constants and repository names
 import 'package:tango/constants.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/word_repository.dart';
 
-// Provide box names for words and learning stats
 const wordsBoxName = WordRepository.boxName;
 const learningStatBoxName = LearningRepository.boxName;
 
-/// Safely register a single adapter if it isn't already registered.
 void _register(TypeAdapter adapter) {
   if (!Hive.isAdapterRegistered(adapter.typeId)) {
     Hive.registerAdapter(adapter);
   }
 }
 
-/// Register all Hive type adapters used by the app.
-/// Each adapter is registered only once.
 void _registerAdapters() {
   _register(WordAdapter());
   _register(LearningStatAdapter());
@@ -47,8 +39,6 @@ void _registerAdapters() {
   _register(FlashcardStateAdapter());
 }
 
-/// Open all persistent boxes used in the app. This helper can be called from tests
-/// that need multiple boxes to be open at once.
 Future<void> openAllBoxes() async {
   await Future.wait([
     openTypedBox(settingsBoxName),
@@ -62,13 +52,11 @@ Future<void> openAllBoxes() async {
   ]);
 }
 
-/// Global setup for tests.
-/// Initializes Hive in a temporary directory and registers all adapters.
-setUpAll(() async {
-  await setUpTestHive();
+ft.setUpAll(() async {
+  Hive.initMemory();
   _registerAdapters();
 });
 
-/// Global teardown for tests.
-/// Closes Hive and cleans up the temporary directory.
-tearDownAll(() async => tearDownTestHive());
+ft.tearDownAll(() async {
+  await Hive.close();
+});


### PR DESCRIPTION
## Summary
- rewrite `test_harness.dart` with `flutter_test` alias
- self‑initialize Hive using `Hive.initMemory`
- provide global `setUpAll`/`tearDownAll` wrappers

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884a1aff80c832a95d35cc1b0e177a3