### PR TITLE
Fix test harness syntax

### DIFF
--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -5,9 +5,10 @@ import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/word_repository.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/flashcard_loader.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late WordRepository wordRepo;
   late LearningRepository learningRepo;
   late HiveFlashcardLoader loader;

--- a/test/history_chart_service_test.dart
+++ b/test/history_chart_service_test.dart
@@ -8,9 +8,10 @@ import 'package:tango/services/history_chart_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/learning_history_detail_screen.dart';
 import 'package:tango/hive_utils.dart' hide openTypedBox;
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late Box<HistoryEntry> historyBox;
   late Box<QuizStat> quizBox;
   late HistoryChartService service;

--- a/test/history_screen_empty_test.dart
+++ b/test/history_screen_empty_test.dart
@@ -5,9 +5,10 @@ import 'package:hive/hive.dart';
 import 'package:tango/history_screen.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
 
   setUpAll(() async {
     await openAllBoxes();

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -4,9 +4,10 @@ import 'package:hive/hive.dart';
 import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/history_service.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late Box<HistoryEntry> box;
   late HistoryService service;
 

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -3,9 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/learning_repository.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late LearningRepository repo;
 
   setUpAll(() async {

--- a/test/quick_quiz_screen_test.dart
+++ b/test/quick_quiz_screen_test.dart
@@ -17,7 +17,7 @@ import 'package:tango/flashcard_repository.dart';
 import 'package:tango/flashcard_repository_provider.dart';
 import 'package:tango/services/flashcard_loader.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 class _FakeLoader implements FlashcardLoader {
   final List<Flashcard> cards;
@@ -28,6 +28,7 @@ class _FakeLoader implements FlashcardLoader {
 }
 
 void main() {
+  initTestHarness();
   late Box<ReviewQueue> queueBox;
   late Box<Map> favBox;
   late Box<LearningStat> statBox;

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -3,9 +3,10 @@ import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/models/review_queue.dart';
 import 'package:tango/services/review_queue_service.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late Box<ReviewQueue> box;
   late ReviewQueueService service;
 

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -4,9 +4,10 @@ import 'package:hive/hive.dart';
 import 'package:tango/models/session_log.dart';
 import 'package:tango/services/aggregator.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late Box<SessionLog> box;
   late SessionAggregator aggregator;
 

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -8,9 +8,10 @@ import 'package:tango/study_session_controller.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/services/review_queue_service.dart';
 import 'package:tango/services/learning_repository.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late Box<SessionLog> logBox;
   late Box<LearningStat> statBox;
   late Box<ReviewQueue> boxQueue;

--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -18,7 +18,7 @@ import 'package:tango/flashcard_repository_provider.dart';
 import 'package:tango/study_session_controller.dart';
 import 'package:tango/study_start_sheet.dart';
 import 'fakes/fake_flashcard_repository.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 class _FakeLoader implements FlashcardLoader {
   final List<Flashcard> cards;
@@ -29,6 +29,7 @@ class _FakeLoader implements FlashcardLoader {
 }
 
 void main() {
+  initTestHarness();
   late Directory dir;
   late Box<SessionLog> logBox;
   late Box<LearningStat> statBox;

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -1,12 +1,9 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart' as ft;
 import 'package:hive/hive.dart';
-import 'package:hive_test/hive_test.dart';
 
-// Re-export openTypedBox for test files
 import 'package:tango/hive_utils.dart' show openTypedBox;
 export 'package:tango/hive_utils.dart' show openTypedBox;
 
-// Model adapters
 import 'package:tango/models/word.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/models/saved_theme_mode.dart';
@@ -17,24 +14,19 @@ import 'package:tango/models/bookmark.dart';
 import 'package:tango/models/flashcard_state.dart';
 import 'package:tango/models/quiz_stat.dart';
 
-// Constants and repository names
 import 'package:tango/constants.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/word_repository.dart';
 
-// Provide box names for words and learning stats
 const wordsBoxName = WordRepository.boxName;
 const learningStatBoxName = LearningRepository.boxName;
 
-/// Safely register a single adapter if it isn't already registered.
 void _register(TypeAdapter adapter) {
   if (!Hive.isAdapterRegistered(adapter.typeId)) {
     Hive.registerAdapter(adapter);
   }
 }
 
-/// Register all Hive type adapters used by the app.
-/// Each adapter is registered only once.
 void _registerAdapters() {
   _register(WordAdapter());
   _register(LearningStatAdapter());
@@ -47,8 +39,6 @@ void _registerAdapters() {
   _register(FlashcardStateAdapter());
 }
 
-/// Open all persistent boxes used in the app. This helper can be called from tests
-/// that need multiple boxes to be open at once.
 Future<void> openAllBoxes() async {
   await Future.wait([
     openTypedBox(settingsBoxName),
@@ -62,13 +52,13 @@ Future<void> openAllBoxes() async {
   ]);
 }
 
-/// Global setup for tests.
-/// Initializes Hive in a temporary directory and registers all adapters.
-setUpAll(() async {
-  await setUpTestHive();
-  _registerAdapters();
-});
+void initTestHarness() {
+  ft.setUpAll(() async {
+    Hive.initMemory();
+    _registerAdapters();
+  });
 
-/// Global teardown for tests.
-/// Closes Hive and cleans up the temporary directory.
-tearDownAll(() async => tearDownTestHive());
+  ft.tearDownAll(() async {
+    await Hive.close();
+  });
+}

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -6,9 +6,10 @@ import 'package:hive/hive.dart';
 import 'package:tango/theme_mode_provider.dart';
 import 'package:tango/models/saved_theme_mode.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late Box<SavedThemeMode> box;
   late ThemeModeNotifier notifier;
 

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -6,7 +6,7 @@ import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/history_service.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/constants.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 Flashcard _card(String id) => Flashcard(
       id: id,
@@ -21,6 +21,7 @@ Flashcard _card(String id) => Flashcard(
     );
 
 void main() {
+  initTestHarness();
   late Box<HistoryEntry> box;
   late HistoryService service;
   late WordHistoryController controller;

--- a/test/word_list_query_test.dart
+++ b/test/word_list_query_test.dart
@@ -2,9 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/flashcard_model.dart';
 import 'package:tango/word_list_query.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   final card1 = Flashcard(
     id: '1',
     term: 'a',

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -2,9 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/word.dart';
 import 'package:tango/services/word_repository.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 void main() {
+  initTestHarness();
   late WordRepository repo;
 
   setUpAll(() async {

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -10,7 +10,7 @@ import 'package:tango/history_entry_model.dart';
 import 'package:tango/services/bookmark_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/wordbook_screen.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 Flashcard _card(int i) => Flashcard(
       id: '$i',
@@ -29,6 +29,7 @@ Flashcard _card(int i) => Flashcard(
     );
 
 void main() {
+  initTestHarness();
   late Box<Bookmark> box;
 
   setUpAll(() async {

--- a/test/wordbook_screen_test.dart
+++ b/test/wordbook_screen_test.dart
@@ -8,7 +8,7 @@ import 'package:tango/models/bookmark.dart';
 import 'package:tango/services/bookmark_service.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/wordbook_screen.dart';
-import 'test_harness.dart' hide setUpAll;
+import 'test_harness.dart';
 
 Flashcard _card(String id, String term) => Flashcard(
       id: id,
@@ -45,6 +45,7 @@ Flashcard _cardWithRelated(String id, String term, List<String> related) =>
     );
 
 void main() {
+  initTestHarness();
   late Box<Bookmark> box;
 
   setUpAll(() async {


### PR DESCRIPTION
## Summary
- rewrite `test_harness.dart` with an `initTestHarness` helper
- call `initTestHarness()` in each test file and drop old hides

## Testing
- `dart format --set-exit-if-changed test/test_harness.dart test/flashcard_loader_test.dart test/history_chart_service_test.dart test/history_screen_empty_test.dart test/history_service_test.dart test/learning_repository_test.dart test/quick_quiz_screen_test.dart test/review_queue_test.dart test/session_aggregator_test.dart test/study_session_controller_test.dart test/study_session_flow_test.dart test/theme_mode_provider_test.dart test/word_history_controller_test.dart test/word_list_query_test.dart test/word_repository_test.dart test/wordbook_appbar_test.dart test/wordbook_screen_test.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test --concurrency=1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884a1aff80c832a95d35cc1b0e177a3