### PR TITLE
Fix repository constructors

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -9,7 +9,7 @@ class LearningRepository {
 
   final Box<LearningStat> _box;
 
-  LearningRepository._(this._box);
+  LearningRepository(this._box);
 
   /// Open the Hive box used for stats and return a repository.
   ///
@@ -30,7 +30,7 @@ class LearningRepository {
     }
     try {
       final box = await openTypedBox<LearningStat>(boxName);
-      return LearningRepository._(box);
+      return LearningRepository(box);
     } catch (e) {
       // ignore: avoid_print
       print('Failed to open $boxName: $e');

--- a/lib/services/word_repository.dart
+++ b/lib/services/word_repository.dart
@@ -11,7 +11,7 @@ class WordRepository {
 
   final Box<Word> _box;
 
-  WordRepository._(this._box);
+  WordRepository(this._box);
 
   /// Open the Hive box used for words.
   static Future<WordRepository> open() async {
@@ -22,7 +22,7 @@ class WordRepository {
       final box = Hive.isBoxOpen(boxName)
           ? Hive.box<Word>(boxName)
           : await Hive.openBox<Word>(boxName);
-      return WordRepository._(box);
+      return WordRepository(box);
     } catch (e) {
       // ignore: avoid_print
       print('Failed to open $boxName: $e');


### PR DESCRIPTION
## Summary
- use non-private constructors in `WordRepository` and `LearningRepository`

## Testing
- `dart format lib/services/word_repository.dart lib/services/learning_repository.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885ac1b7624832aaba4289c6c6e0404