### PR TITLE
Update test harness to open typed Hive boxes

### DIFF
--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -3,8 +3,6 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart' as ft;
 import 'package:hive/hive.dart';
 
-import 'package:tango/hive_utils.dart' show openTypedBox;
-export 'package:tango/hive_utils.dart' show openTypedBox;
 
 // 全てのモデルとアダプターをインポート
 import 'package:tango/models/word.dart';
@@ -18,6 +16,8 @@ import 'package:tango/models/flashcard_state.dart';
 import 'package:tango/models/quiz_stat.dart';
 
 import 'package:tango/constants.dart';
+import 'package:tango/services/learning_repository.dart';
+import 'package:tango/services/word_repository.dart';
 
 // アダプター登録をまとめた関数
 void _registerAdapters() {
@@ -48,19 +48,20 @@ void initTestHarness() {
 
     _registerAdapters();
 
-    // ここで全てのBoxを開いてしまう
-    await Future.wait([
-      openTypedBox(settingsBoxName),
-      openTypedBox(reviewQueueBoxName),
-      openTypedBox(historyBoxName),
-      openTypedBox(learningStatBoxName),
-      openTypedBox(sessionLogBoxName),
-      openTypedBox(bookmarksBoxName),
-      openTypedBox(wordsBoxName),
-      openTypedBox(quizStatsBoxName),
-      openTypedBox(flashcardStateBoxName),
-      openTypedBox(favoritesBoxName),
-    ]);
+    // ☆☆☆ ここが最後の最重要修正点 ☆☆☆
+    // 型を明記してBoxを開く
+    await Hive.openBox<Word>(wordsBoxName);
+    await Hive.openBox<LearningStat>(learningStatBoxName);
+    await Hive.openBox<SessionLog>(sessionLogBoxName);
+    await Hive.openBox<HistoryEntry>(historyBoxName);
+    await Hive.openBox<ReviewQueue>(reviewQueueBoxName);
+    await Hive.openBox<Bookmark>(bookmarksBoxName);
+    await Hive.openBox<QuizStat>(quizStatsBoxName);
+    await Hive.openBox<FlashcardState>(flashcardStateBoxName);
+
+    // 型がないBoxはそのまま開く
+    await Hive.openBox(settingsBoxName);
+    await Hive.openBox(favoritesBoxName);
   });
 
   ft.tearDownAll(() async {


### PR DESCRIPTION
## Summary
- use Hive's generic openBox for typed boxes in tests
- remove `openTypedBox` helper
- register necessary Hive adapters

## Testing
- `dart --version` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6885b2cd36e4832aaab66b72fea7d026