### PR TITLE
Fix Hive test harness

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -9,7 +9,7 @@ class LearningRepository {
 
   final Box<LearningStat> _box;
 
-  LearningRepository._(this._box);
+  LearningRepository(this._box);
 
   /// Open the Hive box used for stats and return a repository.
   ///
@@ -30,7 +30,7 @@ class LearningRepository {
     }
     try {
       final box = await openTypedBox<LearningStat>(boxName);
-      return LearningRepository._(box);
+      return LearningRepository(box);
     } catch (e) {
       // ignore: avoid_print
       print('Failed to open $boxName: $e');

--- a/lib/services/word_repository.dart
+++ b/lib/services/word_repository.dart
@@ -11,7 +11,7 @@ class WordRepository {
 
   final Box<Word> _box;
 
-  WordRepository._(this._box);
+  WordRepository(this._box);
 
   /// Open the Hive box used for words.
   static Future<WordRepository> open() async {
@@ -22,7 +22,7 @@ class WordRepository {
       final box = Hive.isBoxOpen(boxName)
           ? Hive.box<Word>(boxName)
           : await Hive.openBox<Word>(boxName);
-      return WordRepository._(box);
+      return WordRepository(box);
     } catch (e) {
       // ignore: avoid_print
       print('Failed to open $boxName: $e');

--- a/test/box_initializer_test.dart
+++ b/test/box_initializer_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
+import 'package:tango/services/learning_repository.dart';
+import 'package:tango/services/word_repository.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -11,8 +13,8 @@ void main() {
     expect(Hive.isBoxOpen(historyBoxName), isTrue);
     expect(Hive.isBoxOpen(quizStatsBoxName), isTrue);
     expect(Hive.isBoxOpen(flashcardStateBoxName), isTrue);
-    expect(Hive.isBoxOpen(wordsBoxName), isTrue);
-    expect(Hive.isBoxOpen(learningStatBoxName), isTrue);
+    expect(Hive.isBoxOpen(WordRepository.boxName), isTrue);
+    expect(Hive.isBoxOpen(LearningRepository.boxName), isTrue);
     expect(Hive.isBoxOpen(sessionLogBoxName), isTrue);
     expect(Hive.isBoxOpen(reviewQueueBoxName), isTrue);
     expect(Hive.isBoxOpen(settingsBoxName), isTrue);

--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -5,7 +5,6 @@ import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/word_repository.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/flashcard_loader.dart';
-import 'package:tango/constants.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -17,8 +16,8 @@ void main() {
   late Box<LearningStat> statBox;
 
   setUp(() {
-    wordBox = Hive.box<Word>(wordsBoxName);
-    statBox = Hive.box<LearningStat>(learningStatBoxName);
+    wordBox = Hive.box<Word>(WordRepository.boxName);
+    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     wordRepo = WordRepository(wordBox);
     learningRepo = LearningRepository(statBox);
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/learning_repository.dart';
-import 'package:tango/constants.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -12,7 +11,7 @@ void main() {
   late Box<LearningStat> statBox;
 
   setUp(() {
-    statBox = Hive.box<LearningStat>(learningStatBoxName);
+    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     repo = LearningRepository(statBox);
   });
 

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -1,10 +1,7 @@
 import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart' as ft;
 import 'package:hive/hive.dart';
 
-
-// 全てのモデルとアダプターをインポート
 import 'package:tango/models/word.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/models/saved_theme_mode.dart';
@@ -19,14 +16,12 @@ import 'package:tango/constants.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/word_repository.dart';
 
-// アダプター登録をまとめた関数
 void _registerAdapters() {
   void _register(TypeAdapter adapter) {
     if (!Hive.isAdapterRegistered(adapter.typeId)) {
       Hive.registerAdapter(adapter);
     }
   }
-
   _register(WordAdapter());
   _register(LearningStatAdapter());
   _register(SavedThemeModeAdapter());
@@ -40,18 +35,15 @@ void _registerAdapters() {
 
 Directory? _tempDir;
 
-// 唯一のセットアップ関数
 void initTestHarness() {
   ft.setUpAll(() async {
     _tempDir = await Directory.systemTemp.createTemp();
     Hive.init(_tempDir!.path);
-
     _registerAdapters();
 
-    // ☆☆☆ ここが最後の最重要修正点 ☆☆☆
     // 型を明記してBoxを開く
-    await Hive.openBox<Word>(wordsBoxName);
-    await Hive.openBox<LearningStat>(learningStatBoxName);
+    await Hive.openBox<Word>(WordRepository.boxName);
+    await Hive.openBox<LearningStat>(LearningRepository.boxName);
     await Hive.openBox<SessionLog>(sessionLogBoxName);
     await Hive.openBox<HistoryEntry>(historyBoxName);
     await Hive.openBox<ReviewQueue>(reviewQueueBoxName);

--- a/test/word_repository_test.dart
+++ b/test/word_repository_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/word.dart';
 import 'package:tango/services/word_repository.dart';
-import 'package:tango/constants.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -11,7 +10,7 @@ void main() {
   late Box<Word> wordBox;
 
   setUp(() {
-    wordBox = Hive.box<Word>(wordsBoxName);
+    wordBox = Hive.box<Word>(WordRepository.boxName);
     repo = WordRepository(wordBox);
   });
 

--- a/test/wordbook_appbar_test.dart
+++ b/test/wordbook_appbar_test.dart
@@ -37,6 +37,10 @@ void main() {
     await box.clear();
   });
 
+  tearDown(() async {
+    await box.clear();
+  });
+
   testWidgets('shows current page indicator in AppBar', (tester) async {
     final cards = List.generate(861, (i) => _card(i + 1));
     SharedPreferences.setMockInitialValues({'bookmark_pageIndex': 77});


### PR DESCRIPTION
## Summary
- update Hive test harness to open boxes with explicit types
- make `WordRepository` and `LearningRepository` constructors public
- standardize repository tests to use repository box names
- refresh box initializer test and tidy wordbook app bar test

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885b685f9f8832a8c031fe1a556f09b