### PR TITLE
Refactor test setup

### DIFF
--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -5,6 +5,7 @@ import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/word_repository.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/flashcard_loader.dart';
+import 'package:tango/constants.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -16,8 +17,8 @@ void main() {
   late Box<LearningStat> statBox;
 
   setUp(() {
-    wordBox = Hive.box<Word>(WordRepository.boxName);
-    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
+    wordBox = Hive.box<Word>(wordsBoxName);
+    statBox = Hive.box<LearningStat>(learningStatBoxName);
     wordRepo = WordRepository(wordBox);
     learningRepo = LearningRepository(statBox);
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -13,7 +13,6 @@ void main() {
 
   setUp(() async {
     box = Hive.box<HistoryEntry>(historyBoxName);
-    await box.clear();
     service = HistoryService(box);
   });
 

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/learning_repository.dart';
+import 'package:tango/constants.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -11,7 +12,7 @@ void main() {
   late Box<LearningStat> statBox;
 
   setUp(() {
-    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
+    statBox = Hive.box<LearningStat>(learningStatBoxName);
     repo = LearningRepository(statBox);
   });
 

--- a/test/review_queue_test.dart
+++ b/test/review_queue_test.dart
@@ -12,7 +12,6 @@ void main() {
 
   setUp(() async {
     box = Hive.box<ReviewQueue>(reviewQueueBoxName);
-    await box.clear();
     service = ReviewQueueService(box);
   });
 

--- a/test/session_aggregator_test.dart
+++ b/test/session_aggregator_test.dart
@@ -20,7 +20,6 @@ void main() {
 
   setUp(() async {
     box = Hive.box<SessionLog>(sessionLogBoxName);
-    await box.clear();
     aggregator = SessionAggregator(box);
   });
 

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -31,11 +31,8 @@ void main() {
 
   setUp(() async {
     logBox = Hive.box<SessionLog>(sessionLogBoxName);
-    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
+    statBox = Hive.box<LearningStat>(learningStatBoxName);
     boxQueue = Hive.box<ReviewQueue>(reviewQueueBoxName);
-    await logBox.clear();
-    await statBox.clear();
-    await boxQueue.clear();
     controller = StudySessionController(logBox, ReviewQueueService(boxQueue));
   });
 

--- a/test/theme_mode_provider_test.dart
+++ b/test/theme_mode_provider_test.dart
@@ -15,7 +15,6 @@ void main() {
 
   setUp(() async {
     box = Hive.box<SavedThemeMode>(settingsBoxName);
-    await box.clear();
     notifier = ThemeModeNotifier(box);
     await notifier.load();
   });


### PR DESCRIPTION
## Summary
- refactor several tests to match the harness pattern
- rely on constants for box names and only clear in tearDown

## Testing
- `dart format --set-exit-if-changed test/flashcard_loader_test.dart test/history_service_test.dart test/learning_repository_test.dart test/review_queue_test.dart test/session_aggregator_test.dart test/study_session_controller_test.dart test/theme_mode_provider_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d8a624dc832aba046c8dcbc2d5d7