### PR TITLE
Refactor test Hive setup

### DIFF
--- a/test/flashcard_loader_test.dart
+++ b/test/flashcard_loader_test.dart
@@ -5,7 +5,6 @@ import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/word_repository.dart';
 import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/flashcard_loader.dart';
-import 'package:tango/constants.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -17,8 +16,8 @@ void main() {
   late Box<LearningStat> statBox;
 
   setUp(() {
-    wordBox = Hive.box<Word>(wordsBoxName);
-    statBox = Hive.box<LearningStat>(learningStatBoxName);
+    wordBox = Hive.box<Word>(WordRepository.boxName);
+    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     wordRepo = WordRepository(wordBox);
     learningRepo = LearningRepository(statBox);
     loader = HiveFlashcardLoader(wordRepo: wordRepo, learningRepo: learningRepo);

--- a/test/learning_repository_test.dart
+++ b/test/learning_repository_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/models/learning_stat.dart';
 import 'package:tango/services/learning_repository.dart';
-import 'package:tango/constants.dart';
 import 'test_harness.dart';
 
 void main() {
@@ -12,7 +11,7 @@ void main() {
   late Box<LearningStat> statBox;
 
   setUp(() {
-    statBox = Hive.box<LearningStat>(learningStatBoxName);
+    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     repo = LearningRepository(statBox);
   });
 

--- a/test/study_session_controller_test.dart
+++ b/test/study_session_controller_test.dart
@@ -31,7 +31,7 @@ void main() {
 
   setUp(() {
     logBox = Hive.box<SessionLog>(sessionLogBoxName);
-    statBox = Hive.box<LearningStat>(learningStatBoxName);
+    statBox = Hive.box<LearningStat>(LearningRepository.boxName);
     boxQueue = Hive.box<ReviewQueue>(reviewQueueBoxName);
     controller = StudySessionController(logBox, ReviewQueueService(boxQueue));
   });


### PR DESCRIPTION
## Summary
- standardize Hive box initialization across several tests

## Testing
- `dart format --output=none --set-exit-if-changed test/flashcard_loader_test.dart test/learning_repository_test.dart test/study_session_controller_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68861fc8d298832a9326c029eb7897e6