### PR TITLE
Fix test harness and doc comment

### DIFF
--- a/lib/services/learning_repository.dart
+++ b/lib/services/learning_repository.dart
@@ -21,7 +21,7 @@ class LearningRepository {
   /// 3. 開かれていなければ
   ///    → `final box = await Hive.openBox<LearningStat>(boxName);`
   ///    を返す
-  /// 4. 最後に `return LearningRepository._(box);`
+  /// 4. 最後に `return LearningRepository(box);`
   /// 5. `Hive.openBox` が throw する場合は catch してログだけ出す
   static Future<LearningRepository> open() async {
     // Register adapter only once


### PR DESCRIPTION
## Summary
- replace `test_harness.dart` with stable initialization helpers
- update comment in `learning_repository.dart`

## Testing
- `dart format -o none --set-exit-if-changed lib/services/learning_repository.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688634301978832aa5aeea07bb21bd11