### PR TITLE
Fix Hive adapter registration and timer handling

### DIFF
--- a/test/study_session_flow_test.dart
+++ b/test/study_session_flow_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:hive/hive.dart';
 import 'package:tango/constants.dart';
 import 'package:tango/flashcard_model.dart';
@@ -61,42 +62,47 @@ void main() {
 
 
   testWidgets('flow one word', (tester) async {
-    final words = [_card('1')];
-    final repo = FlashcardRepository(loader: _FakeLoader(words));
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          flashcardRepositoryProvider.overrideWith((ref) => repo),
-          studySessionControllerProvider.overrideWith(
-            (ref) => StudySessionController(
-              logBox,
-              ReviewQueueService(queueBox),
+    fakeAsync((async) {
+      async.run(() async {
+        final words = [_card('1')];
+        final repo = FlashcardRepository(loader: _FakeLoader(words));
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              flashcardRepositoryProvider.overrideWith((ref) => repo),
+              studySessionControllerProvider.overrideWith(
+                (ref) => StudySessionController(
+                  logBox,
+                  ReviewQueueService(queueBox),
+                ),
+              ),
+            ],
+            child: MaterialApp(
+              home: Builder(
+                builder: (context) {
+                  return ElevatedButton(
+                    onPressed: () => showStudyStartSheet(context),
+                    child: const Text('start'),
+                  );
+                },
+              ),
             ),
           ),
-        ],
-        child: MaterialApp(
-          home: Builder(
-            builder: (context) {
-              return ElevatedButton(
-                onPressed: () => showStudyStartSheet(context),
-                child: const Text('start'),
-              );
-            },
-          ),
-        ),
-      ),
-    );
+        );
 
-    final startFinder = find.text('start');
-    expect(startFinder, findsOneWidget);
-    await tester.tap(startFinder);
-    await tester.pumpAndSettle();
+        final startFinder = find.text('start');
+        expect(startFinder, findsOneWidget);
+        await tester.tap(startFinder);
+        await tester.pumpAndSettle();
 
-    final beginFinder = find.text('開始');
-    expect(beginFinder, findsOneWidget);
-    await tester.tap(beginFinder);
-    await tester.pumpAndSettle();
+        final beginFinder = find.text('開始');
+        expect(beginFinder, findsOneWidget);
+        await tester.tap(beginFinder);
+        await tester.pumpAndSettle();
 
-    expect(find.byType(StudySessionScreen), findsOneWidget);
+        expect(find.byType(StudySessionScreen), findsOneWidget);
+      });
+      async.flushTimers();
+    });
   });
 }

--- a/test/test_harness.dart
+++ b/test/test_harness.dart
@@ -17,20 +17,33 @@ import 'package:tango/services/learning_repository.dart';
 import 'package:tango/services/word_repository.dart';
 
 void _registerAdapters() {
-  void _register(TypeAdapter adapter) {
-    if (!Hive.isAdapterRegistered(adapter.typeId)) {
-      Hive.registerAdapter(adapter);
-    }
+  if (!Hive.isAdapterRegistered(WordAdapter().typeId)) {
+    Hive.registerAdapter(WordAdapter());
   }
-  _register(WordAdapter());
-  _register(LearningStatAdapter());
-  _register(SavedThemeModeAdapter());
-  _register(HistoryEntryAdapter());
-  _register(ReviewQueueAdapter());
-  _register(SessionLogAdapter());
-  _register(BookmarkAdapter());
-  _register(QuizStatAdapter());
-  _register(FlashcardStateAdapter());
+  if (!Hive.isAdapterRegistered(LearningStatAdapter().typeId)) {
+    Hive.registerAdapter(LearningStatAdapter());
+  }
+  if (!Hive.isAdapterRegistered(SavedThemeModeAdapter().typeId)) {
+    Hive.registerAdapter(SavedThemeModeAdapter());
+  }
+  if (!Hive.isAdapterRegistered(HistoryEntryAdapter().typeId)) {
+    Hive.registerAdapter(HistoryEntryAdapter());
+  }
+  if (!Hive.isAdapterRegistered(ReviewQueueAdapter().typeId)) {
+    Hive.registerAdapter(ReviewQueueAdapter());
+  }
+  if (!Hive.isAdapterRegistered(SessionLogAdapter().typeId)) {
+    Hive.registerAdapter(SessionLogAdapter());
+  }
+  if (!Hive.isAdapterRegistered(BookmarkAdapter().typeId)) {
+    Hive.registerAdapter(BookmarkAdapter());
+  }
+  if (!Hive.isAdapterRegistered(QuizStatAdapter().typeId)) {
+    Hive.registerAdapter(QuizStatAdapter());
+  }
+  if (!Hive.isAdapterRegistered(FlashcardStateAdapter().typeId)) {
+    Hive.registerAdapter(FlashcardStateAdapter());
+  }
 }
 
 Directory? _tempDir;

--- a/test/word_history_controller_test.dart
+++ b/test/word_history_controller_test.dart
@@ -44,9 +44,9 @@ void main() {
     fakeAsync((async) {
       controller.initialize([_card('1')], 0);
       async.elapse(const Duration(seconds: 5));
-      async.flushMicrotasks();
+      expect(box.get('1'), isNotNull);
+      async.flushTimers();
     });
-    expect(box.get('1'), isNotNull);
   });
 
   test('cancels record if page changes quickly', () {
@@ -54,9 +54,9 @@ void main() {
       controller.initialize([_card('1'), _card('2')], 0);
       controller.setPage(1);
       async.elapse(const Duration(seconds: 5));
-      async.flushMicrotasks();
+      expect(box.get('1'), isNull);
+      expect(box.get('2'), isNotNull);
+      async.flushTimers();
     });
-    expect(box.get('1'), isNull);
-    expect(box.get('2'), isNotNull);
   });
 }


### PR DESCRIPTION
## Why
- Hive adapters were registered without specifying type, causing subtype errors
- Async tests with timers left pending leading to timeouts

## What
- register all Hive adapters explicitly
- use fakeAsync with flushTimers in word history controller tests
- wrap study session flow widget test in fakeAsync and flush timers

## How
- updated `_registerAdapters` implementation
- modified tests to manage timers correctly

------
https://chatgpt.com/codex/tasks/task_e_6886393ad87c832a87d5e0f22658b7dd