### PR TITLE
feat: implement favorites tab experience

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -105,7 +105,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         }
         return const Center(child: CircularProgressIndicator());
       case AppScreen.favorites:
-        return const FavoritesContent();
+        return FavoritesContent(navigateTo: _navigateTo);
       case AppScreen.history:
         return const HistoryContent();
       case AppScreen.quiz:

--- a/lib/main_screen/favorites_content.dart
+++ b/lib/main_screen/favorites_content.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 
-import '../tabs_content/placeholder_tab_content.dart';
+import '../tabs_content/favorites_tab_content.dart';
+import '../app_view.dart';
 
 class FavoritesContent extends StatelessWidget {
-  const FavoritesContent({super.key});
+  final void Function(AppScreen, {ScreenArguments? args}) navigateTo;
+
+  const FavoritesContent({super.key, required this.navigateTo});
 
   @override
   Widget build(BuildContext context) {
-    return const PlaceholderTabContent(
-      key: ValueKey('PlaceholderTabContent'),
+    return FavoritesTabContent(
+      key: const ValueKey('FavoritesTabContent'),
+      navigateTo: navigateTo,
     );
   }
 }

--- a/lib/services/bookmark_service.dart
+++ b/lib/services/bookmark_service.dart
@@ -5,11 +5,9 @@ import '../models/bookmark.dart';
 
 class BookmarkService {
   final Box<Bookmark> _box;
-  final Box<dynamic> _pageBox;
 
-  BookmarkService([Box<Bookmark>? box, Box<dynamic>? pageBox])
-      : _box = box ?? Hive.box<Bookmark>(bookmarksBoxName),
-        _pageBox = pageBox ?? Hive.box<dynamic>('bookmark_box');
+  BookmarkService([Box<Bookmark>? box])
+      : _box = box ?? Hive.box<Bookmark>(bookmarksBoxName);
 
   Future<void> addBookmark(int pageIndex) async {
     final entry = Bookmark(pageIndex: pageIndex, updated: DateTime.now());
@@ -28,5 +26,14 @@ class BookmarkService {
     return bookmarks;
   }
 
-  Future<int?> fetch() async => _pageBox.get('page') as int?;
+  Future<int?> fetch() async {
+    if (_box.isEmpty) return null;
+    Bookmark? latest;
+    for (final bookmark in _box.values) {
+      if (latest == null || bookmark.updated.isAfter(latest.updated)) {
+        latest = bookmark;
+      }
+    }
+    return latest?.pageIndex;
+  }
 }

--- a/lib/tabs_content/favorites_tab_content.dart
+++ b/lib/tabs_content/favorites_tab_content.dart
@@ -1,0 +1,307 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../app_view.dart';
+import '../constants.dart';
+import '../flashcard_model.dart';
+import '../flashcard_repository_provider.dart';
+import '../star_color.dart';
+
+class FavoritesTabContent extends ConsumerStatefulWidget {
+  final void Function(AppScreen, {ScreenArguments? args}) navigateTo;
+
+  const FavoritesTabContent({super.key, required this.navigateTo});
+
+  @override
+  ConsumerState<FavoritesTabContent> createState() => _FavoritesTabContentState();
+}
+
+class _FavoriteEntry {
+  final Flashcard card;
+  final Set<StarColor> stars;
+
+  const _FavoriteEntry(this.card, this.stars);
+}
+
+class _FavoritesTabContentState extends ConsumerState<FavoritesTabContent> {
+  late final Box<Map> _favoritesBox;
+  bool _loading = true;
+  String? _error;
+  List<Flashcard> _allCards = const [];
+  final Set<StarColor> _filters = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _favoritesBox = Hive.box<Map>(favoritesBoxName);
+    _loadCards();
+  }
+
+  Future<void> _loadCards() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final cards = await ref.read(flashcardRepositoryProvider).loadAll();
+      if (!mounted) return;
+      setState(() {
+        _allCards = cards;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _error = '単語データの読み込みに失敗しました。';
+        _loading = false;
+      });
+    }
+  }
+
+  void _toggleFilter(StarColor color) {
+    setState(() {
+      if (_filters.contains(color)) {
+        _filters.remove(color);
+      } else {
+        _filters.add(color);
+      }
+    });
+  }
+
+  StarColor? _starFromKey(String key) {
+    for (final color in StarColor.values) {
+      if (color.name == key) {
+        return color;
+      }
+    }
+    return null;
+  }
+
+  List<_FavoriteEntry> _entriesFrom(Box<Map> box) {
+    if (_allCards.isEmpty) {
+      return const [];
+    }
+    final idToCard = {for (final card in _allCards) card.id: card};
+    final List<_FavoriteEntry> entries = [];
+    for (final key in box.keys) {
+      final raw = box.get(key);
+      if (raw is! Map) continue;
+      final card = idToCard[key];
+      if (card == null) continue;
+      final stars = <StarColor>{};
+      raw.forEach((dynamic k, dynamic v) {
+        if (v == true) {
+          final color = _starFromKey(k.toString());
+          if (color != null) {
+            stars.add(color);
+          }
+        }
+      });
+      if (stars.isEmpty) continue;
+      entries.add(_FavoriteEntry(card, stars));
+    }
+    entries.sort((a, b) => a.card.term.compareTo(b.card.term));
+    return entries;
+  }
+
+  Future<void> _toggleStar(String wordId, StarColor color) async {
+    final raw = _favoritesBox.get(wordId);
+    final status = raw is Map
+        ? raw.map((key, value) => MapEntry(key.toString(), value == true))
+        : <String, bool>{};
+    final current = status[color.name] ?? false;
+    status[color.name] = !current;
+    await _favoritesBox.put(wordId, status);
+  }
+
+  Color _colorFor(ThemeData theme, StarColor color) {
+    switch (color) {
+      case StarColor.red:
+        return theme.colorScheme.error;
+      case StarColor.yellow:
+        return theme.colorScheme.secondary;
+      case StarColor.blue:
+        return theme.colorScheme.primary;
+    }
+  }
+
+  Widget _buildFilters(BuildContext context, {required bool hasFavorites}) {
+    final theme = Theme.of(context);
+    final chips = StarColor.values.map((color) {
+      final selected = _filters.contains(color);
+      return FilterChip(
+        avatar: Icon(
+          Icons.star,
+          size: 18,
+          color: selected ? Colors.white : _colorFor(theme, color),
+        ),
+        label: Text('${color.label}星'),
+        selected: selected,
+        onSelected: hasFavorites ? (_) => _toggleFilter(color) : null,
+      );
+    }).toList();
+    if (_filters.isNotEmpty) {
+      chips.add(
+        TextButton.icon(
+          onPressed: () => setState(() => _filters.clear()),
+          icon: const Icon(Icons.clear),
+          label: const Text('フィルター解除'),
+        ),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 4,
+        children: chips,
+      ),
+    );
+  }
+
+  Widget _buildEmptyView(BuildContext context, {required bool hasAnyFavorites}) {
+    final text = hasAnyFavorites
+        ? '選択した星の条件に一致する単語がありません。'
+        : 'お気に入りの単語はまだありません。';
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          text,
+          textAlign: TextAlign.center,
+          style: Theme.of(context)
+              .textTheme
+              .bodyLarge
+              ?.copyWith(color: Theme.of(context).colorScheme.outline),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStarControls(_FavoriteEntry entry, ThemeData theme) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: StarColor.values.map((color) {
+        final active = entry.stars.contains(color);
+        return IconButton(
+          iconSize: 22,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+          visualDensity: VisualDensity.compact,
+          icon: Icon(
+            active ? Icons.star : Icons.star_border,
+            color: active ? _colorFor(theme, color) : theme.colorScheme.outline,
+          ),
+          tooltip: active ? '${color.label}星を解除' : '${color.label}星を付与',
+          onPressed: () => _toggleStar(entry.card.id, color),
+        );
+      }).toList(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyLarge
+                    ?.copyWith(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+            ElevatedButton(
+              onPressed: _loadCards,
+              child: const Text('再試行'),
+            )
+          ],
+        ),
+      );
+    }
+
+    return ValueListenableBuilder<Box<Map>>(
+      valueListenable: _favoritesBox.listenable(),
+      builder: (context, box, _) {
+        final entries = _entriesFrom(box);
+        final filtered = _filters.isEmpty
+            ? entries
+            : entries
+                .where((entry) => entry.stars.any(_filters.contains))
+                .toList();
+        final cards = filtered.map((e) => e.card).toList();
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildFilters(context, hasFavorites: entries.isNotEmpty),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                _filters.isEmpty
+                    ? 'お気に入り: ${entries.length}件'
+                    : 'お気に入り: ${filtered.length} / ${entries.length}件',
+                style: Theme.of(context)
+                    .textTheme
+                    .labelLarge
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (filtered.isEmpty)
+              Expanded(
+                child: _buildEmptyView(
+                  context,
+                  hasAnyFavorites: entries.isNotEmpty,
+                ),
+              )
+            else
+              Expanded(
+                child: ListView.builder(
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) {
+                    final entry = filtered[index];
+                    final theme = Theme.of(context);
+                    return Card(
+                      margin:
+                          const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                      child: ListTile(
+                        title: Text(entry.card.term),
+                        subtitle: Text(
+                          entry.card.description,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        trailing: _buildStarControls(entry, theme),
+                        onTap: () {
+                          widget.navigateTo(
+                            AppScreen.wordDetail,
+                            args: ScreenArguments(
+                              flashcards: cards,
+                              initialIndex: index,
+                            ),
+                          );
+                        },
+                      ),
+                    );
+                  },
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/tabs_content/home_tab_content.dart
+++ b/lib/tabs_content/home_tab_content.dart
@@ -178,6 +178,13 @@ class HomeTabContent extends ConsumerWidget {
                   const SizedBox(height: 8),
                   ElevatedButton(
                     onPressed: () {
+                      navigateTo(AppScreen.favorites);
+                    },
+                    child: const Text('お気に入りを表示'),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: () {
                       navigateTo(AppScreen.learningHistoryDetail);
                     },
                     child: const Text('学習履歴詳細へ'),

--- a/lib/utils/main_screen_utils.dart
+++ b/lib/utils/main_screen_utils.dart
@@ -29,7 +29,7 @@ String getAppBarTitle(
     case AppScreen.wordbookLibrary:
       return '単語帳ライブラリ';
     case AppScreen.favorites:
-      return '準備中';
+      return 'お気に入り';
     case AppScreen.history:
       return '閲覧履歴';
     case AppScreen.quiz:

--- a/test/favorites_tab_content_test.dart
+++ b/test/favorites_tab_content_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import 'package:tango/app_view.dart';
+import 'package:tango/constants.dart';
+import 'package:tango/flashcard_model.dart';
+import 'package:tango/flashcard_repository_provider.dart';
+import 'package:tango/tabs_content/favorites_tab_content.dart';
+
+import 'fakes/fake_flashcard_repository.dart';
+import 'test_harness.dart';
+
+void main() {
+  initTestHarness();
+
+  late Box<Map> favoritesBox;
+
+  Flashcard _card(String id, String term) => Flashcard(
+        id: id,
+        term: term,
+        reading: term,
+        description: 'description $term',
+        categoryLarge: 'A',
+        categoryMedium: 'B',
+        categorySmall: 'C',
+        categoryItem: 'D',
+        importance: 1,
+      );
+
+  setUp(() {
+    favoritesBox = Hive.box<Map>(favoritesBoxName);
+  });
+
+  tearDown(() async {
+    await favoritesBox.clear();
+  });
+
+  testWidgets('renders favorite words and filters by star color', (tester) async {
+    final cards = [_card('1', 'Red'), _card('2', 'Yellow')];
+    await favoritesBox.put('1', {'red': true});
+    await favoritesBox.put('2', {'yellow': true});
+
+    final repo = FakeFlashcardRepository(cards);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [flashcardRepositoryProvider.overrideWithValue(repo)],
+        child: MaterialApp(
+          home: FavoritesTabContent(
+            navigateTo: (_, {args}) {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Red'), findsOneWidget);
+    expect(find.text('Yellow'), findsOneWidget);
+
+    await tester.tap(find.text('赤星'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Red'), findsOneWidget);
+    expect(find.text('Yellow'), findsNothing);
+
+    await tester.tap(find.text('赤星'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Red'), findsOneWidget);
+    expect(find.text('Yellow'), findsOneWidget);
+  });
+
+  testWidgets('toggling star removes word from filtered list', (tester) async {
+    final cards = [_card('1', 'Entry')];
+    await favoritesBox.put('1', {'red': true, 'blue': false});
+
+    final repo = FakeFlashcardRepository(cards);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [flashcardRepositoryProvider.overrideWithValue(repo)],
+        child: MaterialApp(
+          home: FavoritesTabContent(
+            navigateTo: (_, {args}) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Entry'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('赤星を解除'));
+    await tester.pumpAndSettle();
+
+    expect(favoritesBox.get('1'), containsPair('red', false));
+    expect(find.text('Entry'), findsNothing);
+  });
+
+  testWidgets('tapping a word navigates to detail screen', (tester) async {
+    final cards = [_card('1', 'Navigate'), _card('2', 'Also')];
+    await favoritesBox.put('1', {'red': true});
+    await favoritesBox.put('2', {'blue': true});
+
+    final repo = FakeFlashcardRepository(cards);
+
+    AppScreen? lastScreen;
+    ScreenArguments? lastArgs;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [flashcardRepositoryProvider.overrideWithValue(repo)],
+        child: MaterialApp(
+          home: FavoritesTabContent(
+            navigateTo: (screen, {args}) {
+              lastScreen = screen;
+              lastArgs = args;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Navigate'));
+    await tester.pumpAndSettle();
+
+    expect(lastScreen, AppScreen.wordDetail);
+    expect(lastArgs, isNotNull);
+    expect(lastArgs!.flashcards!.first.id, '1');
+    expect(lastArgs!.initialIndex, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- replace the placeholder favorites screen with a fully functional favorites tab backed by Hive
- surface navigation to the favorites view and refresh titles/labels to match the new experience
- streamline bookmark persistence and add widget coverage for the favorites tab behaviour

## Testing
- not run (flutter is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68da9a89e600832a83d80b50733109f4